### PR TITLE
v0.2.2: drop stale precomputed geoadj field from bundled CD data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spm-calculator"
-version = "0.2.1"
+version = "0.2.2"
 description = "Calculate SPM (Supplemental Poverty Measure) thresholds for any US geography and year"
 readme = "README.md"
 license = "MIT"

--- a/spm_calculator/data/README.md
+++ b/spm_calculator/data/README.md
@@ -23,8 +23,6 @@ Where:
 - `national_median_rent` = National median 2-bedroom rent ($1,338 in 2023)
 - `housing_share_t` is tenure-specific (`0.443` renter, `0.434` owner with mortgage, `0.323` owner without mortgage)
 
-Values are clamped to the range [0.70, 1.50] to match Census Bureau practice.
-
 ## Metro thresholds (`metro_geoadj_2024.json`)
 
 Bundled official Census metro threshold data for 2024.

--- a/spm_calculator/data/cd_geoadj_2023.json
+++ b/spm_calculator/data/cd_geoadj_2023.json
@@ -3,2612 +3,2090 @@
   "national_median_2br_rent": 1338.0,
   "congressional_districts": {
     "101": {
-      "geoadj": 0.8757,
       "name": "Congressional District 1 (118th Congress), Alabama",
       "median_2br_rent": 1000.0
     },
     "102": {
-      "geoadj": 0.8312,
       "name": "Congressional District 2 (118th Congress), Alabama",
       "median_2br_rent": 879.0
     },
     "103": {
-      "geoadj": 0.8132,
       "name": "Congressional District 3 (118th Congress), Alabama",
       "median_2br_rent": 830.0
     },
     "104": {
-      "geoadj": 0.7768,
       "name": "Congressional District 4 (118th Congress), Alabama",
       "median_2br_rent": 731.0
     },
     "105": {
-      "geoadj": 0.8507,
       "name": "Congressional District 5 (118th Congress), Alabama",
       "median_2br_rent": 932.0
     },
     "106": {
-      "geoadj": 0.9423,
       "name": "Congressional District 6 (118th Congress), Alabama",
       "median_2br_rent": 1181.0
     },
     "107": {
-      "geoadj": 0.8434,
       "name": "Congressional District 7 (118th Congress), Alabama",
       "median_2br_rent": 912.0
     },
     "200": {
-      "geoadj": 1.0224,
       "name": "Congressional District (at Large) (118th Congress), Alaska",
       "median_2br_rent": 1399.0
     },
     "401": {
-      "geoadj": 1.132,
       "name": "Congressional District 1 (118th Congress), Arizona",
       "median_2br_rent": 1697.0
     },
     "402": {
-      "geoadj": 0.9474,
       "name": "Congressional District 2 (118th Congress), Arizona",
       "median_2br_rent": 1195.0
     },
     "403": {
-      "geoadj": 0.9982,
       "name": "Congressional District 3 (118th Congress), Arizona",
       "median_2br_rent": 1333.0
     },
     "404": {
-      "geoadj": 1.0934,
       "name": "Congressional District 4 (118th Congress), Arizona",
       "median_2br_rent": 1592.0
     },
     "405": {
-      "geoadj": 1.1493,
       "name": "Congressional District 5 (118th Congress), Arizona",
       "median_2br_rent": 1744.0
     },
     "406": {
-      "geoadj": 0.9636,
       "name": "Congressional District 6 (118th Congress), Arizona",
       "median_2br_rent": 1239.0
     },
     "407": {
-      "geoadj": 0.9,
       "name": "Congressional District 7 (118th Congress), Arizona",
       "median_2br_rent": 1066.0
     },
     "408": {
-      "geoadj": 1.0621,
       "name": "Congressional District 8 (118th Congress), Arizona",
       "median_2br_rent": 1507.0
     },
     "409": {
-      "geoadj": 0.9375,
       "name": "Congressional District 9 (118th Congress), Arizona",
       "median_2br_rent": 1168.0
     },
     "501": {
-      "geoadj": 0.7981,
       "name": "Congressional District 1 (118th Congress), Arkansas",
       "median_2br_rent": 789.0
     },
     "502": {
-      "geoadj": 0.8584,
       "name": "Congressional District 2 (118th Congress), Arkansas",
       "median_2br_rent": 953.0
     },
     "503": {
-      "geoadj": 0.8588,
       "name": "Congressional District 3 (118th Congress), Arkansas",
       "median_2br_rent": 954.0
     },
     "504": {
-      "geoadj": 0.7908,
       "name": "Congressional District 4 (118th Congress), Arkansas",
       "median_2br_rent": 769.0
     },
     "601": {
-      "geoadj": 0.9526,
       "name": "Congressional District 1 (118th Congress), California",
       "median_2br_rent": 1209.0
     },
     "602": {
-      "geoadj": 1.2206,
       "name": "Congressional District 2 (118th Congress), California",
       "median_2br_rent": 1938.0
     },
     "603": {
-      "geoadj": 1.1798,
       "name": "Congressional District 3 (118th Congress), California",
       "median_2br_rent": 1827.0
     },
     "604": {
-      "geoadj": 1.2508,
       "name": "Congressional District 4 (118th Congress), California",
       "median_2br_rent": 2020.0
     },
     "605": {
-      "geoadj": 1.0673,
       "name": "Congressional District 5 (118th Congress), California",
       "median_2br_rent": 1521.0
     },
     "606": {
-      "geoadj": 1.1217,
       "name": "Congressional District 6 (118th Congress), California",
       "median_2br_rent": 1669.0
     },
     "607": {
-      "geoadj": 1.1236,
       "name": "Congressional District 7 (118th Congress), California",
       "median_2br_rent": 1674.0
     },
     "608": {
-      "geoadj": 1.2633,
       "name": "Congressional District 8 (118th Congress), California",
       "median_2br_rent": 2054.0
     },
     "609": {
-      "geoadj": 1.0555,
       "name": "Congressional District 9 (118th Congress), California",
       "median_2br_rent": 1489.0
     },
     "610": {
-      "geoadj": 1.446,
       "name": "Congressional District 10 (118th Congress), California",
       "median_2br_rent": 2551.0
     },
     "611": {
-      "geoadj": 1.5,
       "name": "Congressional District 11 (118th Congress), California",
       "median_2br_rent": 3051.0
     },
     "612": {
-      "geoadj": 1.3497,
       "name": "Congressional District 12 (118th Congress), California",
       "median_2br_rent": 2289.0
     },
     "613": {
-      "geoadj": 0.9445,
       "name": "Congressional District 13 (118th Congress), California",
       "median_2br_rent": 1187.0
     },
     "614": {
-      "geoadj": 1.4666,
       "name": "Congressional District 14 (118th Congress), California",
       "median_2br_rent": 2607.0
     },
     "615": {
-      "geoadj": 1.5,
       "name": "Congressional District 15 (118th Congress), California",
       "median_2br_rent": 3103.0
     },
     "616": {
-      "geoadj": 1.5,
       "name": "Congressional District 16 (118th Congress), California",
       "median_2br_rent": 2870.0
     },
     "617": {
-      "geoadj": 1.5,
       "name": "Congressional District 17 (118th Congress), California",
       "median_2br_rent": 3130.0
     },
     "618": {
-      "geoadj": 1.2714,
       "name": "Congressional District 18 (118th Congress), California",
       "median_2br_rent": 2076.0
     },
     "619": {
-      "geoadj": 1.3519,
       "name": "Congressional District 19 (118th Congress), California",
       "median_2br_rent": 2295.0
     },
     "620": {
-      "geoadj": 0.9956,
       "name": "Congressional District 20 (118th Congress), California",
       "median_2br_rent": 1326.0
     },
     "621": {
-      "geoadj": 0.9316,
       "name": "Congressional District 21 (118th Congress), California",
       "median_2br_rent": 1152.0
     },
     "622": {
-      "geoadj": 0.8996,
       "name": "Congressional District 22 (118th Congress), California",
       "median_2br_rent": 1065.0
     },
     "623": {
-      "geoadj": 1.0,
       "name": "Congressional District 23 (118th Congress), California",
       "median_2br_rent": 1338.0
     },
     "624": {
-      "geoadj": 1.2695,
       "name": "Congressional District 24 (118th Congress), California",
       "median_2br_rent": 2071.0
     },
     "625": {
-      "geoadj": 0.9684,
       "name": "Congressional District 25 (118th Congress), California",
       "median_2br_rent": 1252.0
     },
     "626": {
-      "geoadj": 1.3225,
       "name": "Congressional District 26 (118th Congress), California",
       "median_2br_rent": 2215.0
     },
     "627": {
-      "geoadj": 1.2203,
       "name": "Congressional District 27 (118th Congress), California",
       "median_2br_rent": 1937.0
     },
     "628": {
-      "geoadj": 1.289,
       "name": "Congressional District 28 (118th Congress), California",
       "median_2br_rent": 2124.0
     },
     "629": {
-      "geoadj": 1.2545,
       "name": "Congressional District 29 (118th Congress), California",
       "median_2br_rent": 2030.0
     },
     "630": {
-      "geoadj": 1.3894,
       "name": "Congressional District 30 (118th Congress), California",
       "median_2br_rent": 2397.0
     },
     "631": {
-      "geoadj": 1.2103,
       "name": "Congressional District 31 (118th Congress), California",
       "median_2br_rent": 1910.0
     },
     "632": {
-      "geoadj": 1.4291,
       "name": "Congressional District 32 (118th Congress), California",
       "median_2br_rent": 2505.0
     },
     "633": {
-      "geoadj": 1.0923,
       "name": "Congressional District 33 (118th Congress), California",
       "median_2br_rent": 1589.0
     },
     "634": {
-      "geoadj": 1.1842,
       "name": "Congressional District 34 (118th Congress), California",
       "median_2br_rent": 1839.0
     },
     "635": {
-      "geoadj": 1.1982,
       "name": "Congressional District 35 (118th Congress), California",
       "median_2br_rent": 1877.0
     },
     "636": {
-      "geoadj": 1.5,
       "name": "Congressional District 36 (118th Congress), California",
       "median_2br_rent": 2835.0
     },
     "637": {
-      "geoadj": 1.1967,
       "name": "Congressional District 37 (118th Congress), California",
       "median_2br_rent": 1873.0
     },
     "638": {
-      "geoadj": 1.2188,
       "name": "Congressional District 38 (118th Congress), California",
       "median_2br_rent": 1933.0
     },
     "639": {
-      "geoadj": 1.1647,
       "name": "Congressional District 39 (118th Congress), California",
       "median_2br_rent": 1786.0
     },
     "640": {
-      "geoadj": 1.4427,
       "name": "Congressional District 40 (118th Congress), California",
       "median_2br_rent": 2542.0
     },
     "641": {
-      "geoadj": 1.171,
       "name": "Congressional District 41 (118th Congress), California",
       "median_2br_rent": 1803.0
     },
     "642": {
-      "geoadj": 1.1975,
       "name": "Congressional District 42 (118th Congress), California",
       "median_2br_rent": 1875.0
     },
     "643": {
-      "geoadj": 1.1688,
       "name": "Congressional District 43 (118th Congress), California",
       "median_2br_rent": 1797.0
     },
     "644": {
-      "geoadj": 1.1699,
       "name": "Congressional District 44 (118th Congress), California",
       "median_2br_rent": 1800.0
     },
     "645": {
-      "geoadj": 1.3004,
       "name": "Congressional District 45 (118th Congress), California",
       "median_2br_rent": 2155.0
     },
     "646": {
-      "geoadj": 1.2861,
       "name": "Congressional District 46 (118th Congress), California",
       "median_2br_rent": 2116.0
     },
     "647": {
-      "geoadj": 1.5,
       "name": "Congressional District 47 (118th Congress), California",
       "median_2br_rent": 2789.0
     },
     "648": {
-      "geoadj": 1.2306,
       "name": "Congressional District 48 (118th Congress), California",
       "median_2br_rent": 1965.0
     },
     "649": {
-      "geoadj": 1.4015,
       "name": "Congressional District 49 (118th Congress), California",
       "median_2br_rent": 2430.0
     },
     "650": {
-      "geoadj": 1.4126,
       "name": "Congressional District 50 (118th Congress), California",
       "median_2br_rent": 2460.0
     },
     "651": {
-      "geoadj": 1.3365,
       "name": "Congressional District 51 (118th Congress), California",
       "median_2br_rent": 2253.0
     },
     "652": {
-      "geoadj": 1.1971,
       "name": "Congressional District 52 (118th Congress), California",
       "median_2br_rent": 1874.0
     },
     "801": {
-      "geoadj": 1.228,
       "name": "Congressional District 1 (118th Congress), Colorado",
       "median_2br_rent": 1958.0
     },
     "802": {
-      "geoadj": 1.1669,
       "name": "Congressional District 2 (118th Congress), Colorado",
       "median_2br_rent": 1792.0
     },
     "803": {
-      "geoadj": 0.9158,
       "name": "Congressional District 3 (118th Congress), Colorado",
       "median_2br_rent": 1109.0
     },
     "804": {
-      "geoadj": 1.1324,
       "name": "Congressional District 4 (118th Congress), Colorado",
       "median_2br_rent": 1698.0
     },
     "805": {
-      "geoadj": 1.0596,
       "name": "Congressional District 5 (118th Congress), Colorado",
       "median_2br_rent": 1500.0
     },
     "806": {
-      "geoadj": 1.1905,
       "name": "Congressional District 6 (118th Congress), Colorado",
       "median_2br_rent": 1856.0
     },
     "807": {
-      "geoadj": 1.1636,
       "name": "Congressional District 7 (118th Congress), Colorado",
       "median_2br_rent": 1783.0
     },
     "808": {
-      "geoadj": 1.1088,
       "name": "Congressional District 8 (118th Congress), Colorado",
       "median_2br_rent": 1634.0
     },
     "901": {
-      "geoadj": 1.039,
       "name": "Congressional District 1 (118th Congress), Connecticut",
       "median_2br_rent": 1444.0
     },
     "902": {
-      "geoadj": 1.0324,
       "name": "Congressional District 2 (118th Congress), Connecticut",
       "median_2br_rent": 1426.0
     },
     "903": {
-      "geoadj": 1.078,
       "name": "Congressional District 3 (118th Congress), Connecticut",
       "median_2br_rent": 1550.0
     },
     "904": {
-      "geoadj": 1.2217,
       "name": "Congressional District 4 (118th Congress), Connecticut",
       "median_2br_rent": 1941.0
     },
     "905": {
-      "geoadj": 1.0096,
       "name": "Congressional District 5 (118th Congress), Connecticut",
       "median_2br_rent": 1364.0
     },
     "1000": {
-      "geoadj": 0.9967,
       "name": "Congressional District (at Large) (118th Congress), Delaware",
       "median_2br_rent": 1329.0
     },
     "1198": {
-      "geoadj": 1.2247,
       "name": "Delegate District (at Large) (118th Congress), District of Columbia",
       "median_2br_rent": 1949.0
     },
     "1201": {
-      "geoadj": 0.9599,
       "name": "Congressional District 1 (118th Congress), Florida",
       "median_2br_rent": 1229.0
     },
     "1202": {
-      "geoadj": 0.9485,
       "name": "Congressional District 2 (118th Congress), Florida",
       "median_2br_rent": 1198.0
     },
     "1203": {
-      "geoadj": 0.9323,
       "name": "Congressional District 3 (118th Congress), Florida",
       "median_2br_rent": 1154.0
     },
     "1204": {
-      "geoadj": 0.9437,
       "name": "Congressional District 4 (118th Congress), Florida",
       "median_2br_rent": 1185.0
     },
     "1205": {
-      "geoadj": 1.0978,
       "name": "Congressional District 5 (118th Congress), Florida",
       "median_2br_rent": 1604.0
     },
     "1206": {
-      "geoadj": 0.9533,
       "name": "Congressional District 6 (118th Congress), Florida",
       "median_2br_rent": 1211.0
     },
     "1207": {
-      "geoadj": 1.0883,
       "name": "Congressional District 7 (118th Congress), Florida",
       "median_2br_rent": 1578.0
     },
     "1208": {
-      "geoadj": 1.0096,
       "name": "Congressional District 8 (118th Congress), Florida",
       "median_2br_rent": 1364.0
     },
     "1209": {
-      "geoadj": 1.1184,
       "name": "Congressional District 9 (118th Congress), Florida",
       "median_2br_rent": 1660.0
     },
     "1210": {
-      "geoadj": 1.0963,
       "name": "Congressional District 10 (118th Congress), Florida",
       "median_2br_rent": 1600.0
     },
     "1211": {
-      "geoadj": 1.0934,
       "name": "Congressional District 11 (118th Congress), Florida",
       "median_2br_rent": 1592.0
     },
     "1212": {
-      "geoadj": 0.9426,
       "name": "Congressional District 12 (118th Congress), Florida",
       "median_2br_rent": 1182.0
     },
     "1213": {
-      "geoadj": 1.0956,
       "name": "Congressional District 13 (118th Congress), Florida",
       "median_2br_rent": 1598.0
     },
     "1214": {
-      "geoadj": 1.1184,
       "name": "Congressional District 14 (118th Congress), Florida",
       "median_2br_rent": 1660.0
     },
     "1215": {
-      "geoadj": 1.0099,
       "name": "Congressional District 15 (118th Congress), Florida",
       "median_2br_rent": 1365.0
     },
     "1216": {
-      "geoadj": 1.0886,
       "name": "Congressional District 16 (118th Congress), Florida",
       "median_2br_rent": 1579.0
     },
     "1217": {
-      "geoadj": 1.0515,
       "name": "Congressional District 17 (118th Congress), Florida",
       "median_2br_rent": 1478.0
     },
     "1218": {
-      "geoadj": 0.9011,
       "name": "Congressional District 18 (118th Congress), Florida",
       "median_2br_rent": 1069.0
     },
     "1219": {
-      "geoadj": 1.1015,
       "name": "Congressional District 19 (118th Congress), Florida",
       "median_2br_rent": 1614.0
     },
     "1220": {
-      "geoadj": 1.121,
       "name": "Congressional District 20 (118th Congress), Florida",
       "median_2br_rent": 1667.0
     },
     "1221": {
-      "geoadj": 1.1092,
       "name": "Congressional District 21 (118th Congress), Florida",
       "median_2br_rent": 1635.0
     },
     "1222": {
-      "geoadj": 1.1533,
       "name": "Congressional District 22 (118th Congress), Florida",
       "median_2br_rent": 1755.0
     },
     "1223": {
-      "geoadj": 1.221,
       "name": "Congressional District 23 (118th Congress), Florida",
       "median_2br_rent": 1939.0
     },
     "1224": {
-      "geoadj": 1.1603,
       "name": "Congressional District 24 (118th Congress), Florida",
       "median_2br_rent": 1774.0
     },
     "1225": {
-      "geoadj": 1.21,
       "name": "Congressional District 25 (118th Congress), Florida",
       "median_2br_rent": 1909.0
     },
     "1226": {
-      "geoadj": 1.1519,
       "name": "Congressional District 26 (118th Congress), Florida",
       "median_2br_rent": 1751.0
     },
     "1227": {
-      "geoadj": 1.1912,
       "name": "Congressional District 27 (118th Congress), Florida",
       "median_2br_rent": 1858.0
     },
     "1228": {
-      "geoadj": 1.1331,
       "name": "Congressional District 28 (118th Congress), Florida",
       "median_2br_rent": 1700.0
     },
     "1301": {
-      "geoadj": 0.9235,
       "name": "Congressional District 1 (118th Congress), Georgia",
       "median_2br_rent": 1130.0
     },
     "1302": {
-      "geoadj": 0.8327,
       "name": "Congressional District 2 (118th Congress), Georgia",
       "median_2br_rent": 883.0
     },
     "1303": {
-      "geoadj": 0.8945,
       "name": "Congressional District 3 (118th Congress), Georgia",
       "median_2br_rent": 1051.0
     },
     "1304": {
-      "geoadj": 1.078,
       "name": "Congressional District 4 (118th Congress), Georgia",
       "median_2br_rent": 1550.0
     },
     "1305": {
-      "geoadj": 1.0732,
       "name": "Congressional District 5 (118th Congress), Georgia",
       "median_2br_rent": 1537.0
     },
     "1306": {
-      "geoadj": 1.1493,
       "name": "Congressional District 6 (118th Congress), Georgia",
       "median_2br_rent": 1744.0
     },
     "1307": {
-      "geoadj": 1.1173,
       "name": "Congressional District 7 (118th Congress), Georgia",
       "median_2br_rent": 1657.0
     },
     "1308": {
-      "geoadj": 0.8279,
       "name": "Congressional District 8 (118th Congress), Georgia",
       "median_2br_rent": 870.0
     },
     "1309": {
-      "geoadj": 0.9261,
       "name": "Congressional District 9 (118th Congress), Georgia",
       "median_2br_rent": 1137.0
     },
     "1310": {
-      "geoadj": 0.9077,
       "name": "Congressional District 10 (118th Congress), Georgia",
       "median_2br_rent": 1087.0
     },
     "1311": {
-      "geoadj": 1.0978,
       "name": "Congressional District 11 (118th Congress), Georgia",
       "median_2br_rent": 1604.0
     },
     "1312": {
-      "geoadj": 0.8492,
       "name": "Congressional District 12 (118th Congress), Georgia",
       "median_2br_rent": 928.0
     },
     "1313": {
-      "geoadj": 0.9974,
       "name": "Congressional District 13 (118th Congress), Georgia",
       "median_2br_rent": 1331.0
     },
     "1314": {
-      "geoadj": 0.8301,
       "name": "Congressional District 14 (118th Congress), Georgia",
       "median_2br_rent": 876.0
     },
     "1501": {
-      "geoadj": 1.2607,
       "name": "Congressional District 1 (118th Congress), Hawaii",
       "median_2br_rent": 2047.0
     },
     "1502": {
-      "geoadj": 1.1967,
       "name": "Congressional District 2 (118th Congress), Hawaii",
       "median_2br_rent": 1873.0
     },
     "1601": {
-      "geoadj": 0.9077,
       "name": "Congressional District 1 (118th Congress), Idaho",
       "median_2br_rent": 1087.0
     },
     "1602": {
-      "geoadj": 0.904,
       "name": "Congressional District 2 (118th Congress), Idaho",
       "median_2br_rent": 1077.0
     },
     "1701": {
-      "geoadj": 0.9338,
       "name": "Congressional District 1 (118th Congress), Illinois",
       "median_2br_rent": 1158.0
     },
     "1702": {
-      "geoadj": 0.9011,
       "name": "Congressional District 2 (118th Congress), Illinois",
       "median_2br_rent": 1069.0
     },
     "1703": {
-      "geoadj": 1.0382,
       "name": "Congressional District 3 (118th Congress), Illinois",
       "median_2br_rent": 1442.0
     },
     "1704": {
-      "geoadj": 0.9235,
       "name": "Congressional District 4 (118th Congress), Illinois",
       "median_2br_rent": 1130.0
     },
     "1705": {
-      "geoadj": 1.2044,
       "name": "Congressional District 5 (118th Congress), Illinois",
       "median_2br_rent": 1894.0
     },
     "1706": {
-      "geoadj": 1.0316,
       "name": "Congressional District 6 (118th Congress), Illinois",
       "median_2br_rent": 1424.0
     },
     "1707": {
-      "geoadj": 1.0349,
       "name": "Congressional District 7 (118th Congress), Illinois",
       "median_2br_rent": 1433.0
     },
     "1708": {
-      "geoadj": 1.0985,
       "name": "Congressional District 8 (118th Congress), Illinois",
       "median_2br_rent": 1606.0
     },
     "1709": {
-      "geoadj": 1.1081,
       "name": "Congressional District 9 (118th Congress), Illinois",
       "median_2br_rent": 1632.0
     },
     "1710": {
-      "geoadj": 1.0268,
       "name": "Congressional District 10 (118th Congress), Illinois",
       "median_2br_rent": 1411.0
     },
     "1711": {
-      "geoadj": 1.0941,
       "name": "Congressional District 11 (118th Congress), Illinois",
       "median_2br_rent": 1594.0
     },
     "1712": {
-      "geoadj": 0.8081,
       "name": "Congressional District 12 (118th Congress), Illinois",
       "median_2br_rent": 816.0
     },
     "1713": {
-      "geoadj": 0.868,
       "name": "Congressional District 13 (118th Congress), Illinois",
       "median_2br_rent": 979.0
     },
     "1714": {
-      "geoadj": 0.9573,
       "name": "Congressional District 14 (118th Congress), Illinois",
       "median_2br_rent": 1222.0
     },
     "1715": {
-      "geoadj": 0.8161,
       "name": "Congressional District 15 (118th Congress), Illinois",
       "median_2br_rent": 838.0
     },
     "1716": {
-      "geoadj": 0.8768,
       "name": "Congressional District 16 (118th Congress), Illinois",
       "median_2br_rent": 1003.0
     },
     "1717": {
-      "geoadj": 0.8404,
       "name": "Congressional District 17 (118th Congress), Illinois",
       "median_2br_rent": 904.0
     },
     "1801": {
-      "geoadj": 0.9092,
       "name": "Congressional District 1 (118th Congress), Indiana",
       "median_2br_rent": 1091.0
     },
     "1802": {
-      "geoadj": 0.8753,
       "name": "Congressional District 2 (118th Congress), Indiana",
       "median_2br_rent": 999.0
     },
     "1803": {
-      "geoadj": 0.8474,
       "name": "Congressional District 3 (118th Congress), Indiana",
       "median_2br_rent": 923.0
     },
     "1804": {
-      "geoadj": 0.8967,
       "name": "Congressional District 4 (118th Congress), Indiana",
       "median_2br_rent": 1057.0
     },
     "1805": {
-      "geoadj": 0.886,
       "name": "Congressional District 5 (118th Congress), Indiana",
       "median_2br_rent": 1028.0
     },
     "1806": {
-      "geoadj": 0.8812,
       "name": "Congressional District 6 (118th Congress), Indiana",
       "median_2br_rent": 1015.0
     },
     "1807": {
-      "geoadj": 0.925,
       "name": "Congressional District 7 (118th Congress), Indiana",
       "median_2br_rent": 1134.0
     },
     "1808": {
-      "geoadj": 0.8503,
       "name": "Congressional District 8 (118th Congress), Indiana",
       "median_2br_rent": 931.0
     },
     "1809": {
-      "geoadj": 0.8735,
       "name": "Congressional District 9 (118th Congress), Indiana",
       "median_2br_rent": 994.0
     },
     "1901": {
-      "geoadj": 0.8603,
       "name": "Congressional District 1 (118th Congress), Iowa",
       "median_2br_rent": 958.0
     },
     "1902": {
-      "geoadj": 0.847,
       "name": "Congressional District 2 (118th Congress), Iowa",
       "median_2br_rent": 922.0
     },
     "1903": {
-      "geoadj": 0.9121,
       "name": "Congressional District 3 (118th Congress), Iowa",
       "median_2br_rent": 1099.0
     },
     "1904": {
-      "geoadj": 0.8356,
       "name": "Congressional District 4 (118th Congress), Iowa",
       "median_2br_rent": 891.0
     },
     "2001": {
-      "geoadj": 0.8437,
       "name": "Congressional District 1 (118th Congress), Kansas",
       "median_2br_rent": 913.0
     },
     "2002": {
-      "geoadj": 0.8452,
       "name": "Congressional District 2 (118th Congress), Kansas",
       "median_2br_rent": 917.0
     },
     "2003": {
-      "geoadj": 1.0099,
       "name": "Congressional District 3 (118th Congress), Kansas",
       "median_2br_rent": 1365.0
     },
     "2004": {
-      "geoadj": 0.8588,
       "name": "Congressional District 4 (118th Congress), Kansas",
       "median_2br_rent": 954.0
     },
     "2101": {
-      "geoadj": 0.8095,
       "name": "Congressional District 1 (118th Congress), Kentucky",
       "median_2br_rent": 820.0
     },
     "2102": {
-      "geoadj": 0.8294,
       "name": "Congressional District 2 (118th Congress), Kentucky",
       "median_2br_rent": 874.0
     },
     "2103": {
-      "geoadj": 0.9195,
       "name": "Congressional District 3 (118th Congress), Kentucky",
       "median_2br_rent": 1119.0
     },
     "2104": {
-      "geoadj": 0.893,
       "name": "Congressional District 4 (118th Congress), Kentucky",
       "median_2br_rent": 1047.0
     },
     "2105": {
-      "geoadj": 0.7742,
       "name": "Congressional District 5 (118th Congress), Kentucky",
       "median_2br_rent": 724.0
     },
     "2106": {
-      "geoadj": 0.8621,
       "name": "Congressional District 6 (118th Congress), Kentucky",
       "median_2br_rent": 963.0
     },
     "2201": {
-      "geoadj": 0.9566,
       "name": "Congressional District 1 (118th Congress), Louisiana",
       "median_2br_rent": 1220.0
     },
     "2202": {
-      "geoadj": 0.9331,
       "name": "Congressional District 2 (118th Congress), Louisiana",
       "median_2br_rent": 1156.0
     },
     "2203": {
-      "geoadj": 0.8559,
       "name": "Congressional District 3 (118th Congress), Louisiana",
       "median_2br_rent": 946.0
     },
     "2204": {
-      "geoadj": 0.8279,
       "name": "Congressional District 4 (118th Congress), Louisiana",
       "median_2br_rent": 870.0
     },
     "2205": {
-      "geoadj": 0.8161,
       "name": "Congressional District 5 (118th Congress), Louisiana",
       "median_2br_rent": 838.0
     },
     "2206": {
-      "geoadj": 0.9257,
       "name": "Congressional District 6 (118th Congress), Louisiana",
       "median_2br_rent": 1136.0
     },
     "2301": {
-      "geoadj": 1.0287,
       "name": "Congressional District 1 (118th Congress), Maine",
       "median_2br_rent": 1416.0
     },
     "2302": {
-      "geoadj": 0.8702,
       "name": "Congressional District 2 (118th Congress), Maine",
       "median_2br_rent": 985.0
     },
     "2401": {
-      "geoadj": 0.9768,
       "name": "Congressional District 1 (118th Congress), Maryland",
       "median_2br_rent": 1275.0
     },
     "2402": {
-      "geoadj": 1.1199,
       "name": "Congressional District 2 (118th Congress), Maryland",
       "median_2br_rent": 1664.0
     },
     "2403": {
-      "geoadj": 1.2236,
       "name": "Congressional District 3 (118th Congress), Maryland",
       "median_2br_rent": 1946.0
     },
     "2404": {
-      "geoadj": 1.1644,
       "name": "Congressional District 4 (118th Congress), Maryland",
       "median_2br_rent": 1785.0
     },
     "2405": {
-      "geoadj": 1.2081,
       "name": "Congressional District 5 (118th Congress), Maryland",
       "median_2br_rent": 1904.0
     },
     "2406": {
-      "geoadj": 1.1059,
       "name": "Congressional District 6 (118th Congress), Maryland",
       "median_2br_rent": 1626.0
     },
     "2407": {
-      "geoadj": 1.0107,
       "name": "Congressional District 7 (118th Congress), Maryland",
       "median_2br_rent": 1367.0
     },
     "2408": {
-      "geoadj": 1.278,
       "name": "Congressional District 8 (118th Congress), Maryland",
       "median_2br_rent": 2094.0
     },
     "2501": {
-      "geoadj": 0.9456,
       "name": "Congressional District 1 (118th Congress), Massachusetts",
       "median_2br_rent": 1190.0
     },
     "2502": {
-      "geoadj": 1.0574,
       "name": "Congressional District 2 (118th Congress), Massachusetts",
       "median_2br_rent": 1494.0
     },
     "2503": {
-      "geoadj": 1.1224,
       "name": "Congressional District 3 (118th Congress), Massachusetts",
       "median_2br_rent": 1671.0
     },
     "2504": {
-      "geoadj": 1.1059,
       "name": "Congressional District 4 (118th Congress), Massachusetts",
       "median_2br_rent": 1626.0
     },
     "2505": {
-      "geoadj": 1.3692,
       "name": "Congressional District 5 (118th Congress), Massachusetts",
       "median_2br_rent": 2342.0
     },
     "2506": {
-      "geoadj": 1.2295,
       "name": "Congressional District 6 (118th Congress), Massachusetts",
       "median_2br_rent": 1962.0
     },
     "2507": {
-      "geoadj": 1.2953,
       "name": "Congressional District 7 (118th Congress), Massachusetts",
       "median_2br_rent": 2141.0
     },
     "2508": {
-      "geoadj": 1.3236,
       "name": "Congressional District 8 (118th Congress), Massachusetts",
       "median_2br_rent": 2218.0
     },
     "2509": {
-      "geoadj": 1.0614,
       "name": "Congressional District 9 (118th Congress), Massachusetts",
       "median_2br_rent": 1505.0
     },
     "2601": {
-      "geoadj": 0.8353,
       "name": "Congressional District 1 (118th Congress), Michigan",
       "median_2br_rent": 890.0
     },
     "2602": {
-      "geoadj": 0.8349,
       "name": "Congressional District 2 (118th Congress), Michigan",
       "median_2br_rent": 889.0
     },
     "2603": {
-      "geoadj": 0.9448,
       "name": "Congressional District 3 (118th Congress), Michigan",
       "median_2br_rent": 1188.0
     },
     "2604": {
-      "geoadj": 0.9011,
       "name": "Congressional District 4 (118th Congress), Michigan",
       "median_2br_rent": 1069.0
     },
     "2605": {
-      "geoadj": 0.8625,
       "name": "Congressional District 5 (118th Congress), Michigan",
       "median_2br_rent": 964.0
     },
     "2606": {
-      "geoadj": 1.0404,
       "name": "Congressional District 6 (118th Congress), Michigan",
       "median_2br_rent": 1448.0
     },
     "2607": {
-      "geoadj": 0.9169,
       "name": "Congressional District 7 (118th Congress), Michigan",
       "median_2br_rent": 1112.0
     },
     "2608": {
-      "geoadj": 0.8559,
       "name": "Congressional District 8 (118th Congress), Michigan",
       "median_2br_rent": 946.0
     },
     "2609": {
-      "geoadj": 0.8952,
       "name": "Congressional District 9 (118th Congress), Michigan",
       "median_2br_rent": 1053.0
     },
     "2610": {
-      "geoadj": 0.9566,
       "name": "Congressional District 10 (118th Congress), Michigan",
       "median_2br_rent": 1220.0
     },
     "2611": {
-      "geoadj": 1.0243,
       "name": "Congressional District 11 (118th Congress), Michigan",
       "median_2br_rent": 1404.0
     },
     "2612": {
-      "geoadj": 0.9371,
       "name": "Congressional District 12 (118th Congress), Michigan",
       "median_2br_rent": 1167.0
     },
     "2613": {
-      "geoadj": 0.8794,
       "name": "Congressional District 13 (118th Congress), Michigan",
       "median_2br_rent": 1010.0
     },
     "2701": {
-      "geoadj": 0.8772,
       "name": "Congressional District 1 (118th Congress), Minnesota",
       "median_2br_rent": 1004.0
     },
     "2702": {
-      "geoadj": 1.064,
       "name": "Congressional District 2 (118th Congress), Minnesota",
       "median_2br_rent": 1512.0
     },
     "2703": {
-      "geoadj": 1.1125,
       "name": "Congressional District 3 (118th Congress), Minnesota",
       "median_2br_rent": 1644.0
     },
     "2704": {
-      "geoadj": 1.0375,
       "name": "Congressional District 4 (118th Congress), Minnesota",
       "median_2br_rent": 1440.0
     },
     "2705": {
-      "geoadj": 1.0618,
       "name": "Congressional District 5 (118th Congress), Minnesota",
       "median_2br_rent": 1506.0
     },
     "2706": {
-      "geoadj": 0.947,
       "name": "Congressional District 6 (118th Congress), Minnesota",
       "median_2br_rent": 1194.0
     },
     "2707": {
-      "geoadj": 0.8309,
       "name": "Congressional District 7 (118th Congress), Minnesota",
       "median_2br_rent": 878.0
     },
     "2708": {
-      "geoadj": 0.8893,
       "name": "Congressional District 8 (118th Congress), Minnesota",
       "median_2br_rent": 1037.0
     },
     "2801": {
-      "geoadj": 0.8121,
       "name": "Congressional District 1 (118th Congress), Mississippi",
       "median_2br_rent": 827.0
     },
     "2802": {
-      "geoadj": 0.8011,
       "name": "Congressional District 2 (118th Congress), Mississippi",
       "median_2br_rent": 797.0
     },
     "2803": {
-      "geoadj": 0.8621,
       "name": "Congressional District 3 (118th Congress), Mississippi",
       "median_2br_rent": 963.0
     },
     "2804": {
-      "geoadj": 0.8555,
       "name": "Congressional District 4 (118th Congress), Mississippi",
       "median_2br_rent": 945.0
     },
     "2901": {
-      "geoadj": 0.9187,
       "name": "Congressional District 1 (118th Congress), Missouri",
       "median_2br_rent": 1117.0
     },
     "2902": {
-      "geoadj": 0.9467,
       "name": "Congressional District 2 (118th Congress), Missouri",
       "median_2br_rent": 1193.0
     },
     "2903": {
-      "geoadj": 0.861,
       "name": "Congressional District 3 (118th Congress), Missouri",
       "median_2br_rent": 960.0
     },
     "2904": {
-      "geoadj": 0.8316,
       "name": "Congressional District 4 (118th Congress), Missouri",
       "median_2br_rent": 880.0
     },
     "2905": {
-      "geoadj": 0.9316,
       "name": "Congressional District 5 (118th Congress), Missouri",
       "median_2br_rent": 1152.0
     },
     "2906": {
-      "geoadj": 0.8415,
       "name": "Congressional District 6 (118th Congress), Missouri",
       "median_2br_rent": 907.0
     },
     "2907": {
-      "geoadj": 0.8386,
       "name": "Congressional District 7 (118th Congress), Missouri",
       "median_2br_rent": 899.0
     },
     "2908": {
-      "geoadj": 0.7996,
       "name": "Congressional District 8 (118th Congress), Missouri",
       "median_2br_rent": 793.0
     },
     "3001": {
-      "geoadj": 0.9165,
       "name": "Congressional District 1 (118th Congress), Montana",
       "median_2br_rent": 1111.0
     },
     "3002": {
-      "geoadj": 0.8647,
       "name": "Congressional District 2 (118th Congress), Montana",
       "median_2br_rent": 970.0
     },
     "3101": {
-      "geoadj": 0.9018,
       "name": "Congressional District 1 (118th Congress), Nebraska",
       "median_2br_rent": 1071.0
     },
     "3102": {
-      "geoadj": 0.9515,
       "name": "Congressional District 2 (118th Congress), Nebraska",
       "median_2br_rent": 1206.0
     },
     "3103": {
-      "geoadj": 0.8228,
       "name": "Congressional District 3 (118th Congress), Nebraska",
       "median_2br_rent": 856.0
     },
     "3201": {
-      "geoadj": 1.0011,
       "name": "Congressional District 1 (118th Congress), Nevada",
       "median_2br_rent": 1341.0
     },
     "3202": {
-      "geoadj": 1.0283,
       "name": "Congressional District 2 (118th Congress), Nevada",
       "median_2br_rent": 1415.0
     },
     "3203": {
-      "geoadj": 1.0919,
       "name": "Congressional District 3 (118th Congress), Nevada",
       "median_2br_rent": 1588.0
     },
     "3204": {
-      "geoadj": 0.9952,
       "name": "Congressional District 4 (118th Congress), Nevada",
       "median_2br_rent": 1325.0
     },
     "3301": {
-      "geoadj": 1.103,
       "name": "Congressional District 1 (118th Congress), New Hampshire",
       "median_2br_rent": 1618.0
     },
     "3302": {
-      "geoadj": 1.0518,
       "name": "Congressional District 2 (118th Congress), New Hampshire",
       "median_2br_rent": 1479.0
     },
     "3401": {
-      "geoadj": 1.0621,
       "name": "Congressional District 1 (118th Congress), New Jersey",
       "median_2br_rent": 1507.0
     },
     "3402": {
-      "geoadj": 1.0059,
       "name": "Congressional District 2 (118th Congress), New Jersey",
       "median_2br_rent": 1354.0
     },
     "3403": {
-      "geoadj": 1.1699,
       "name": "Congressional District 3 (118th Congress), New Jersey",
       "median_2br_rent": 1800.0
     },
     "3404": {
-      "geoadj": 1.1463,
       "name": "Congressional District 4 (118th Congress), New Jersey",
       "median_2br_rent": 1736.0
     },
     "3405": {
-      "geoadj": 1.2541,
       "name": "Congressional District 5 (118th Congress), New Jersey",
       "median_2br_rent": 2029.0
     },
     "3406": {
-      "geoadj": 1.2317,
       "name": "Congressional District 6 (118th Congress), New Jersey",
       "median_2br_rent": 1968.0
     },
     "3407": {
-      "geoadj": 1.214,
       "name": "Congressional District 7 (118th Congress), New Jersey",
       "median_2br_rent": 1920.0
     },
     "3408": {
-      "geoadj": 1.1478,
       "name": "Congressional District 8 (118th Congress), New Jersey",
       "median_2br_rent": 1740.0
     },
     "3409": {
-      "geoadj": 1.1302,
       "name": "Congressional District 9 (118th Congress), New Jersey",
       "median_2br_rent": 1692.0
     },
     "3410": {
-      "geoadj": 1.0824,
       "name": "Congressional District 10 (118th Congress), New Jersey",
       "median_2br_rent": 1562.0
     },
     "3411": {
-      "geoadj": 1.264,
       "name": "Congressional District 11 (118th Congress), New Jersey",
       "median_2br_rent": 2056.0
     },
     "3412": {
-      "geoadj": 1.1938,
       "name": "Congressional District 12 (118th Congress), New Jersey",
       "median_2br_rent": 1865.0
     },
     "3501": {
-      "geoadj": 0.9276,
       "name": "Congressional District 1 (118th Congress), New Mexico",
       "median_2br_rent": 1141.0
     },
     "3502": {
-      "geoadj": 0.8224,
       "name": "Congressional District 2 (118th Congress), New Mexico",
       "median_2br_rent": 855.0
     },
     "3503": {
-      "geoadj": 0.8636,
       "name": "Congressional District 3 (118th Congress), New Mexico",
       "median_2br_rent": 967.0
     },
     "3601": {
-      "geoadj": 1.3379,
       "name": "Congressional District 1 (118th Congress), New York",
       "median_2br_rent": 2257.0
     },
     "3602": {
-      "geoadj": 1.3247,
       "name": "Congressional District 2 (118th Congress), New York",
       "median_2br_rent": 2221.0
     },
     "3603": {
-      "geoadj": 1.3434,
       "name": "Congressional District 3 (118th Congress), New York",
       "median_2br_rent": 2272.0
     },
     "3604": {
-      "geoadj": 1.2773,
       "name": "Congressional District 4 (118th Congress), New York",
       "median_2br_rent": 2092.0
     },
     "3605": {
-      "geoadj": 1.1699,
       "name": "Congressional District 5 (118th Congress), New York",
       "median_2br_rent": 1800.0
     },
     "3606": {
-      "geoadj": 1.2688,
       "name": "Congressional District 6 (118th Congress), New York",
       "median_2br_rent": 2069.0
     },
     "3607": {
-      "geoadj": 1.239,
       "name": "Congressional District 7 (118th Congress), New York",
       "median_2br_rent": 1988.0
     },
     "3608": {
-      "geoadj": 1.0842,
       "name": "Congressional District 8 (118th Congress), New York",
       "median_2br_rent": 1567.0
     },
     "3609": {
-      "geoadj": 1.1706,
       "name": "Congressional District 9 (118th Congress), New York",
       "median_2br_rent": 1802.0
     },
     "3610": {
-      "geoadj": 1.2747,
       "name": "Congressional District 10 (118th Congress), New York",
       "median_2br_rent": 2085.0
     },
     "3611": {
-      "geoadj": 1.1666,
       "name": "Congressional District 11 (118th Congress), New York",
       "median_2br_rent": 1791.0
     },
     "3612": {
-      "geoadj": 1.5,
       "name": "Congressional District 12 (118th Congress), New York",
       "median_2br_rent": 3338.0
     },
     "3613": {
-      "geoadj": 1.0636,
       "name": "Congressional District 13 (118th Congress), New York",
       "median_2br_rent": 1511.0
     },
     "3614": {
-      "geoadj": 1.1566,
       "name": "Congressional District 14 (118th Congress), New York",
       "median_2br_rent": 1764.0
     },
     "3615": {
-      "geoadj": 1.0419,
       "name": "Congressional District 15 (118th Congress), New York",
       "median_2br_rent": 1452.0
     },
     "3616": {
-      "geoadj": 1.2078,
       "name": "Congressional District 16 (118th Congress), New York",
       "median_2br_rent": 1903.0
     },
     "3617": {
-      "geoadj": 1.2309,
       "name": "Congressional District 17 (118th Congress), New York",
       "median_2br_rent": 1966.0
     },
     "3618": {
-      "geoadj": 1.1191,
       "name": "Congressional District 18 (118th Congress), New York",
       "median_2br_rent": 1662.0
     },
     "3619": {
-      "geoadj": 0.9055,
       "name": "Congressional District 19 (118th Congress), New York",
       "median_2br_rent": 1081.0
     },
     "3620": {
-      "geoadj": 0.9937,
       "name": "Congressional District 20 (118th Congress), New York",
       "median_2br_rent": 1321.0
     },
     "3621": {
-      "geoadj": 0.8871,
       "name": "Congressional District 21 (118th Congress), New York",
       "median_2br_rent": 1031.0
     },
     "3622": {
-      "geoadj": 0.907,
       "name": "Congressional District 22 (118th Congress), New York",
       "median_2br_rent": 1085.0
     },
     "3623": {
-      "geoadj": 0.8573,
       "name": "Congressional District 23 (118th Congress), New York",
       "median_2br_rent": 950.0
     },
     "3624": {
-      "geoadj": 0.8643,
       "name": "Congressional District 24 (118th Congress), New York",
       "median_2br_rent": 969.0
     },
     "3625": {
-      "geoadj": 0.9507,
       "name": "Congressional District 25 (118th Congress), New York",
       "median_2br_rent": 1204.0
     },
     "3626": {
-      "geoadj": 0.8805,
       "name": "Congressional District 26 (118th Congress), New York",
       "median_2br_rent": 1013.0
     },
     "3701": {
-      "geoadj": 0.8272,
       "name": "Congressional District 1 (118th Congress), North Carolina",
       "median_2br_rent": 868.0
     },
     "3702": {
-      "geoadj": 1.0599,
       "name": "Congressional District 2 (118th Congress), North Carolina",
       "median_2br_rent": 1501.0
     },
     "3703": {
-      "geoadj": 0.8511,
       "name": "Congressional District 3 (118th Congress), North Carolina",
       "median_2br_rent": 933.0
     },
     "3704": {
-      "geoadj": 0.9783,
       "name": "Congressional District 4 (118th Congress), North Carolina",
       "median_2br_rent": 1279.0
     },
     "3705": {
-      "geoadj": 0.8382,
       "name": "Congressional District 5 (118th Congress), North Carolina",
       "median_2br_rent": 898.0
     },
     "3706": {
-      "geoadj": 0.8812,
       "name": "Congressional District 6 (118th Congress), North Carolina",
       "median_2br_rent": 1015.0
     },
     "3707": {
-      "geoadj": 0.904,
       "name": "Congressional District 7 (118th Congress), North Carolina",
       "median_2br_rent": 1077.0
     },
     "3708": {
-      "geoadj": 0.8261,
       "name": "Congressional District 8 (118th Congress), North Carolina",
       "median_2br_rent": 865.0
     },
     "3709": {
-      "geoadj": 0.8742,
       "name": "Congressional District 9 (118th Congress), North Carolina",
       "median_2br_rent": 996.0
     },
     "3710": {
-      "geoadj": 0.8161,
       "name": "Congressional District 10 (118th Congress), North Carolina",
       "median_2br_rent": 838.0
     },
     "3711": {
-      "geoadj": 0.8937,
       "name": "Congressional District 11 (118th Congress), North Carolina",
       "median_2br_rent": 1049.0
     },
     "3712": {
-      "geoadj": 1.0195,
       "name": "Congressional District 12 (118th Congress), North Carolina",
       "median_2br_rent": 1391.0
     },
     "3713": {
-      "geoadj": 0.9191,
       "name": "Congressional District 13 (118th Congress), North Carolina",
       "median_2br_rent": 1118.0
     },
     "3714": {
-      "geoadj": 1.0441,
       "name": "Congressional District 14 (118th Congress), North Carolina",
       "median_2br_rent": 1458.0
     },
     "3800": {
-      "geoadj": 0.8514,
       "name": "Congressional District (at Large) (118th Congress), North Dakota",
       "median_2br_rent": 934.0
     },
     "3901": {
-      "geoadj": 0.9165,
       "name": "Congressional District 1 (118th Congress), Ohio",
       "median_2br_rent": 1111.0
     },
     "3902": {
-      "geoadj": 0.8301,
       "name": "Congressional District 2 (118th Congress), Ohio",
       "median_2br_rent": 876.0
     },
     "3903": {
-      "geoadj": 0.9647,
       "name": "Congressional District 3 (118th Congress), Ohio",
       "median_2br_rent": 1242.0
     },
     "3904": {
-      "geoadj": 0.8529,
       "name": "Congressional District 4 (118th Congress), Ohio",
       "median_2br_rent": 938.0
     },
     "3905": {
-      "geoadj": 0.829,
       "name": "Congressional District 5 (118th Congress), Ohio",
       "median_2br_rent": 873.0
     },
     "3906": {
-      "geoadj": 0.8055,
       "name": "Congressional District 6 (118th Congress), Ohio",
       "median_2br_rent": 809.0
     },
     "3907": {
-      "geoadj": 0.9191,
       "name": "Congressional District 7 (118th Congress), Ohio",
       "median_2br_rent": 1118.0
     },
     "3908": {
-      "geoadj": 0.8867,
       "name": "Congressional District 8 (118th Congress), Ohio",
       "median_2br_rent": 1030.0
     },
     "3909": {
-      "geoadj": 0.8485,
       "name": "Congressional District 9 (118th Congress), Ohio",
       "median_2br_rent": 926.0
     },
     "3910": {
-      "geoadj": 0.8658,
       "name": "Congressional District 10 (118th Congress), Ohio",
       "median_2br_rent": 973.0
     },
     "3911": {
-      "geoadj": 0.875,
       "name": "Congressional District 11 (118th Congress), Ohio",
       "median_2br_rent": 998.0
     },
     "3912": {
-      "geoadj": 0.8537,
       "name": "Congressional District 12 (118th Congress), Ohio",
       "median_2br_rent": 940.0
     },
     "3913": {
-      "geoadj": 0.8643,
       "name": "Congressional District 13 (118th Congress), Ohio",
       "median_2br_rent": 969.0
     },
     "3914": {
-      "geoadj": 0.8566,
       "name": "Congressional District 14 (118th Congress), Ohio",
       "median_2br_rent": 948.0
     },
     "3915": {
-      "geoadj": 0.9559,
       "name": "Congressional District 15 (118th Congress), Ohio",
       "median_2br_rent": 1218.0
     },
     "4001": {
-      "geoadj": 0.9007,
       "name": "Congressional District 1 (118th Congress), Oklahoma",
       "median_2br_rent": 1068.0
     },
     "4002": {
-      "geoadj": 0.8003,
       "name": "Congressional District 2 (118th Congress), Oklahoma",
       "median_2br_rent": 795.0
     },
     "4003": {
-      "geoadj": 0.832,
       "name": "Congressional District 3 (118th Congress), Oklahoma",
       "median_2br_rent": 881.0
     },
     "4004": {
-      "geoadj": 0.8617,
       "name": "Congressional District 4 (118th Congress), Oklahoma",
       "median_2br_rent": 962.0
     },
     "4005": {
-      "geoadj": 0.9055,
       "name": "Congressional District 5 (118th Congress), Oklahoma",
       "median_2br_rent": 1081.0
     },
     "4101": {
-      "geoadj": 1.1452,
       "name": "Congressional District 1 (118th Congress), Oregon",
       "median_2br_rent": 1733.0
     },
     "4102": {
-      "geoadj": 0.9026,
       "name": "Congressional District 2 (118th Congress), Oregon",
       "median_2br_rent": 1073.0
     },
     "4103": {
-      "geoadj": 1.1022,
       "name": "Congressional District 3 (118th Congress), Oregon",
       "median_2br_rent": 1616.0
     },
     "4104": {
-      "geoadj": 0.9658,
       "name": "Congressional District 4 (118th Congress), Oregon",
       "median_2br_rent": 1245.0
     },
     "4105": {
-      "geoadj": 1.0735,
       "name": "Congressional District 5 (118th Congress), Oregon",
       "median_2br_rent": 1538.0
     },
     "4106": {
-      "geoadj": 1.0368,
       "name": "Congressional District 6 (118th Congress), Oregon",
       "median_2br_rent": 1438.0
     },
     "4201": {
-      "geoadj": 1.1085,
       "name": "Congressional District 1 (118th Congress), Pennsylvania",
       "median_2br_rent": 1633.0
     },
     "4202": {
-      "geoadj": 0.9971,
       "name": "Congressional District 2 (118th Congress), Pennsylvania",
       "median_2br_rent": 1330.0
     },
     "4203": {
-      "geoadj": 1.0441,
       "name": "Congressional District 3 (118th Congress), Pennsylvania",
       "median_2br_rent": 1458.0
     },
     "4204": {
-      "geoadj": 1.1177,
       "name": "Congressional District 4 (118th Congress), Pennsylvania",
       "median_2br_rent": 1658.0
     },
     "4205": {
-      "geoadj": 1.0449,
       "name": "Congressional District 5 (118th Congress), Pennsylvania",
       "median_2br_rent": 1460.0
     },
     "4206": {
-      "geoadj": 1.0585,
       "name": "Congressional District 6 (118th Congress), Pennsylvania",
       "median_2br_rent": 1497.0
     },
     "4207": {
-      "geoadj": 1.0051,
       "name": "Congressional District 7 (118th Congress), Pennsylvania",
       "median_2br_rent": 1352.0
     },
     "4208": {
-      "geoadj": 0.8728,
       "name": "Congressional District 8 (118th Congress), Pennsylvania",
       "median_2br_rent": 992.0
     },
     "4209": {
-      "geoadj": 0.8529,
       "name": "Congressional District 9 (118th Congress), Pennsylvania",
       "median_2br_rent": 938.0
     },
     "4210": {
-      "geoadj": 0.9478,
       "name": "Congressional District 10 (118th Congress), Pennsylvania",
       "median_2br_rent": 1196.0
     },
     "4211": {
-      "geoadj": 0.9768,
       "name": "Congressional District 11 (118th Congress), Pennsylvania",
       "median_2br_rent": 1275.0
     },
     "4212": {
-      "geoadj": 0.9257,
       "name": "Congressional District 12 (118th Congress), Pennsylvania",
       "median_2br_rent": 1136.0
     },
     "4213": {
-      "geoadj": 0.8356,
       "name": "Congressional District 13 (118th Congress), Pennsylvania",
       "median_2br_rent": 891.0
     },
     "4214": {
-      "geoadj": 0.8224,
       "name": "Congressional District 14 (118th Congress), Pennsylvania",
       "median_2br_rent": 855.0
     },
     "4215": {
-      "geoadj": 0.8331,
       "name": "Congressional District 15 (118th Congress), Pennsylvania",
       "median_2br_rent": 884.0
     },
     "4216": {
-      "geoadj": 0.8367,
       "name": "Congressional District 16 (118th Congress), Pennsylvania",
       "median_2br_rent": 894.0
     },
     "4217": {
-      "geoadj": 0.9213,
       "name": "Congressional District 17 (118th Congress), Pennsylvania",
       "median_2br_rent": 1124.0
     },
     "4401": {
-      "geoadj": 0.9993,
       "name": "Congressional District 1 (118th Congress), Rhode Island",
       "median_2br_rent": 1336.0
     },
     "4402": {
-      "geoadj": 1.0147,
       "name": "Congressional District 2 (118th Congress), Rhode Island",
       "median_2br_rent": 1378.0
     },
     "4501": {
-      "geoadj": 1.0673,
       "name": "Congressional District 1 (118th Congress), South Carolina",
       "median_2br_rent": 1521.0
     },
     "4502": {
-      "geoadj": 0.9077,
       "name": "Congressional District 2 (118th Congress), South Carolina",
       "median_2br_rent": 1087.0
     },
     "4503": {
-      "geoadj": 0.8327,
       "name": "Congressional District 3 (118th Congress), South Carolina",
       "median_2br_rent": 883.0
     },
     "4504": {
-      "geoadj": 0.9257,
       "name": "Congressional District 4 (118th Congress), South Carolina",
       "median_2br_rent": 1136.0
     },
     "4505": {
-      "geoadj": 0.8783,
       "name": "Congressional District 5 (118th Congress), South Carolina",
       "median_2br_rent": 1007.0
     },
     "4506": {
-      "geoadj": 0.9368,
       "name": "Congressional District 6 (118th Congress), South Carolina",
       "median_2br_rent": 1166.0
     },
     "4507": {
-      "geoadj": 0.8639,
       "name": "Congressional District 7 (118th Congress), South Carolina",
       "median_2br_rent": 968.0
     },
     "4600": {
-      "geoadj": 0.8573,
       "name": "Congressional District (at Large) (118th Congress), South Dakota",
       "median_2br_rent": 950.0
     },
     "4701": {
-      "geoadj": 0.8206,
       "name": "Congressional District 1 (118th Congress), Tennessee",
       "median_2br_rent": 850.0
     },
     "4702": {
-      "geoadj": 0.9224,
       "name": "Congressional District 2 (118th Congress), Tennessee",
       "median_2br_rent": 1127.0
     },
     "4703": {
-      "geoadj": 0.8706,
       "name": "Congressional District 3 (118th Congress), Tennessee",
       "median_2br_rent": 986.0
     },
     "4704": {
-      "geoadj": 0.8882,
       "name": "Congressional District 4 (118th Congress), Tennessee",
       "median_2br_rent": 1034.0
     },
     "4705": {
-      "geoadj": 1.0655,
       "name": "Congressional District 5 (118th Congress), Tennessee",
       "median_2br_rent": 1516.0
     },
     "4706": {
-      "geoadj": 0.9327,
       "name": "Congressional District 6 (118th Congress), Tennessee",
       "median_2br_rent": 1155.0
     },
     "4707": {
-      "geoadj": 0.9526,
       "name": "Congressional District 7 (118th Congress), Tennessee",
       "median_2br_rent": 1209.0
     },
     "4708": {
-      "geoadj": 0.8099,
       "name": "Congressional District 8 (118th Congress), Tennessee",
       "median_2br_rent": 821.0
     },
     "4709": {
-      "geoadj": 0.907,
       "name": "Congressional District 9 (118th Congress), Tennessee",
       "median_2br_rent": 1085.0
     },
     "4801": {
-      "geoadj": 0.8787,
       "name": "Congressional District 1 (118th Congress), Texas",
       "median_2br_rent": 1008.0
     },
     "4802": {
-      "geoadj": 1.0853,
       "name": "Congressional District 2 (118th Congress), Texas",
       "median_2br_rent": 1570.0
     },
     "4803": {
-      "geoadj": 1.1452,
       "name": "Congressional District 3 (118th Congress), Texas",
       "median_2br_rent": 1733.0
     },
     "4804": {
-      "geoadj": 1.1026,
       "name": "Congressional District 4 (118th Congress), Texas",
       "median_2br_rent": 1617.0
     },
     "4805": {
-      "geoadj": 0.9805,
       "name": "Congressional District 5 (118th Congress), Texas",
       "median_2br_rent": 1285.0
     },
     "4806": {
-      "geoadj": 1.0033,
       "name": "Congressional District 6 (118th Congress), Texas",
       "median_2br_rent": 1347.0
     },
     "4807": {
-      "geoadj": 1.0776,
       "name": "Congressional District 7 (118th Congress), Texas",
       "median_2br_rent": 1549.0
     },
     "4808": {
-      "geoadj": 1.0257,
       "name": "Congressional District 8 (118th Congress), Texas",
       "median_2br_rent": 1408.0
     },
     "4809": {
-      "geoadj": 0.971,
       "name": "Congressional District 9 (118th Congress), Texas",
       "median_2br_rent": 1259.0
     },
     "4810": {
-      "geoadj": 0.9331,
       "name": "Congressional District 10 (118th Congress), Texas",
       "median_2br_rent": 1156.0
     },
     "4811": {
-      "geoadj": 0.9379,
       "name": "Congressional District 11 (118th Congress), Texas",
       "median_2br_rent": 1169.0
     },
     "4812": {
-      "geoadj": 1.0397,
       "name": "Congressional District 12 (118th Congress), Texas",
       "median_2br_rent": 1446.0
     },
     "4813": {
-      "geoadj": 0.8945,
       "name": "Congressional District 13 (118th Congress), Texas",
       "median_2br_rent": 1051.0
     },
     "4814": {
-      "geoadj": 0.9522,
       "name": "Congressional District 14 (118th Congress), Texas",
       "median_2br_rent": 1208.0
     },
     "4815": {
-      "geoadj": 0.8562,
       "name": "Congressional District 15 (118th Congress), Texas",
       "median_2br_rent": 947.0
     },
     "4816": {
-      "geoadj": 0.8724,
       "name": "Congressional District 16 (118th Congress), Texas",
       "median_2br_rent": 991.0
     },
     "4817": {
-      "geoadj": 0.9165,
       "name": "Congressional District 17 (118th Congress), Texas",
       "median_2br_rent": 1111.0
     },
     "4818": {
-      "geoadj": 0.975,
       "name": "Congressional District 18 (118th Congress), Texas",
       "median_2br_rent": 1270.0
     },
     "4819": {
-      "geoadj": 0.8901,
       "name": "Congressional District 19 (118th Congress), Texas",
       "median_2br_rent": 1039.0
     },
     "4820": {
-      "geoadj": 0.9846,
       "name": "Congressional District 20 (118th Congress), Texas",
       "median_2br_rent": 1296.0
     },
     "4821": {
-      "geoadj": 1.0434,
       "name": "Congressional District 21 (118th Congress), Texas",
       "median_2br_rent": 1456.0
     },
     "4822": {
-      "geoadj": 1.0754,
       "name": "Congressional District 22 (118th Congress), Texas",
       "median_2br_rent": 1543.0
     },
     "4823": {
-      "geoadj": 0.9239,
       "name": "Congressional District 23 (118th Congress), Texas",
       "median_2br_rent": 1131.0
     },
     "4824": {
-      "geoadj": 1.15,
       "name": "Congressional District 24 (118th Congress), Texas",
       "median_2br_rent": 1746.0
     },
     "4825": {
-      "geoadj": 0.9835,
       "name": "Congressional District 25 (118th Congress), Texas",
       "median_2br_rent": 1293.0
     },
     "4826": {
-      "geoadj": 1.1574,
       "name": "Congressional District 26 (118th Congress), Texas",
       "median_2br_rent": 1766.0
     },
     "4827": {
-      "geoadj": 0.9467,
       "name": "Congressional District 27 (118th Congress), Texas",
       "median_2br_rent": 1193.0
     },
     "4828": {
-      "geoadj": 0.8867,
       "name": "Congressional District 28 (118th Congress), Texas",
       "median_2br_rent": 1030.0
     },
     "4829": {
-      "geoadj": 0.9393,
       "name": "Congressional District 29 (118th Congress), Texas",
       "median_2br_rent": 1173.0
     },
     "4830": {
-      "geoadj": 1.0537,
       "name": "Congressional District 30 (118th Congress), Texas",
       "median_2br_rent": 1484.0
     },
     "4831": {
-      "geoadj": 0.9654,
       "name": "Congressional District 31 (118th Congress), Texas",
       "median_2br_rent": 1244.0
     },
     "4832": {
-      "geoadj": 1.1037,
       "name": "Congressional District 32 (118th Congress), Texas",
       "median_2br_rent": 1620.0
     },
     "4833": {
-      "geoadj": 1.0213,
       "name": "Congressional District 33 (118th Congress), Texas",
       "median_2br_rent": 1396.0
     },
     "4834": {
-      "geoadj": 0.8257,
       "name": "Congressional District 34 (118th Congress), Texas",
       "median_2br_rent": 864.0
     },
     "4835": {
-      "geoadj": 1.0316,
       "name": "Congressional District 35 (118th Congress), Texas",
       "median_2br_rent": 1424.0
     },
     "4836": {
-      "geoadj": 0.9757,
       "name": "Congressional District 36 (118th Congress), Texas",
       "median_2br_rent": 1272.0
     },
     "4837": {
-      "geoadj": 1.1706,
       "name": "Congressional District 37 (118th Congress), Texas",
       "median_2br_rent": 1802.0
     },
     "4838": {
-      "geoadj": 1.1195,
       "name": "Congressional District 38 (118th Congress), Texas",
       "median_2br_rent": 1663.0
     },
     "4901": {
-      "geoadj": 0.9687,
       "name": "Congressional District 1 (118th Congress), Utah",
       "median_2br_rent": 1253.0
     },
     "4902": {
-      "geoadj": 0.9915,
       "name": "Congressional District 2 (118th Congress), Utah",
       "median_2br_rent": 1315.0
     },
     "4903": {
-      "geoadj": 0.9879,
       "name": "Congressional District 3 (118th Congress), Utah",
       "median_2br_rent": 1305.0
     },
     "4904": {
-      "geoadj": 1.0485,
       "name": "Congressional District 4 (118th Congress), Utah",
       "median_2br_rent": 1470.0
     },
     "5000": {
-      "geoadj": 0.996,
       "name": "Congressional District (at Large) (118th Congress), Vermont",
       "median_2br_rent": 1327.0
     },
     "5101": {
-      "geoadj": 1.0566,
       "name": "Congressional District 1 (118th Congress), Virginia",
       "median_2br_rent": 1492.0
     },
     "5102": {
-      "geoadj": 1.0544,
       "name": "Congressional District 2 (118th Congress), Virginia",
       "median_2br_rent": 1486.0
     },
     "5103": {
-      "geoadj": 0.9643,
       "name": "Congressional District 3 (118th Congress), Virginia",
       "median_2br_rent": 1241.0
     },
     "5104": {
-      "geoadj": 0.979,
       "name": "Congressional District 4 (118th Congress), Virginia",
       "median_2br_rent": 1281.0
     },
     "5105": {
-      "geoadj": 0.8772,
       "name": "Congressional District 5 (118th Congress), Virginia",
       "median_2br_rent": 1004.0
     },
     "5106": {
-      "geoadj": 0.875,
       "name": "Congressional District 6 (118th Congress), Virginia",
       "median_2br_rent": 998.0
     },
     "5107": {
-      "geoadj": 1.1129,
       "name": "Congressional District 7 (118th Congress), Virginia",
       "median_2br_rent": 1645.0
     },
     "5108": {
-      "geoadj": 1.3427,
       "name": "Congressional District 8 (118th Congress), Virginia",
       "median_2br_rent": 2270.0
     },
     "5109": {
-      "geoadj": 0.8022,
       "name": "Congressional District 9 (118th Congress), Virginia",
       "median_2br_rent": 800.0
     },
     "5110": {
-      "geoadj": 1.2456,
       "name": "Congressional District 10 (118th Congress), Virginia",
       "median_2br_rent": 2006.0
     },
     "5111": {
-      "geoadj": 1.3552,
       "name": "Congressional District 11 (118th Congress), Virginia",
       "median_2br_rent": 2304.0
     },
     "5301": {
-      "geoadj": 1.3324,
       "name": "Congressional District 1 (118th Congress), Washington",
       "median_2br_rent": 2242.0
     },
     "5302": {
-      "geoadj": 1.1096,
       "name": "Congressional District 2 (118th Congress), Washington",
       "median_2br_rent": 1636.0
     },
     "5303": {
-      "geoadj": 1.0357,
       "name": "Congressional District 3 (118th Congress), Washington",
       "median_2br_rent": 1435.0
     },
     "5304": {
-      "geoadj": 0.9231,
       "name": "Congressional District 4 (118th Congress), Washington",
       "median_2br_rent": 1129.0
     },
     "5305": {
-      "geoadj": 0.9357,
       "name": "Congressional District 5 (118th Congress), Washington",
       "median_2br_rent": 1163.0
     },
     "5306": {
-      "geoadj": 1.1008,
       "name": "Congressional District 6 (118th Congress), Washington",
       "median_2br_rent": 1612.0
     },
     "5307": {
-      "geoadj": 1.3585,
       "name": "Congressional District 7 (118th Congress), Washington",
       "median_2br_rent": 2313.0
     },
     "5308": {
-      "geoadj": 1.15,
       "name": "Congressional District 8 (118th Congress), Washington",
       "median_2br_rent": 1746.0
     },
     "5309": {
-      "geoadj": 1.21,
       "name": "Congressional District 9 (118th Congress), Washington",
       "median_2br_rent": 1909.0
     },
     "5310": {
-      "geoadj": 1.118,
       "name": "Congressional District 10 (118th Congress), Washington",
       "median_2br_rent": 1659.0
     },
     "5401": {
-      "geoadj": 0.8132,
       "name": "Congressional District 1 (118th Congress), West Virginia",
       "median_2br_rent": 830.0
     },
     "5402": {
-      "geoadj": 0.8411,
       "name": "Congressional District 2 (118th Congress), West Virginia",
       "median_2br_rent": 906.0
     },
     "5501": {
-      "geoadj": 0.9184,
       "name": "Congressional District 1 (118th Congress), Wisconsin",
       "median_2br_rent": 1116.0
     },
     "5502": {
-      "geoadj": 0.9993,
       "name": "Congressional District 2 (118th Congress), Wisconsin",
       "median_2br_rent": 1336.0
     },
     "5503": {
-      "geoadj": 0.8606,
       "name": "Congressional District 3 (118th Congress), Wisconsin",
       "median_2br_rent": 959.0
     },
     "5504": {
-      "geoadj": 0.9018,
       "name": "Congressional District 4 (118th Congress), Wisconsin",
       "median_2br_rent": 1071.0
     },
     "5505": {
-      "geoadj": 0.9504,
       "name": "Congressional District 5 (118th Congress), Wisconsin",
       "median_2br_rent": 1203.0
     },
     "5506": {
-      "geoadj": 0.8566,
       "name": "Congressional District 6 (118th Congress), Wisconsin",
       "median_2br_rent": 948.0
     },
     "5507": {
-      "geoadj": 0.8459,
       "name": "Congressional District 7 (118th Congress), Wisconsin",
       "median_2br_rent": 919.0
     },
     "5508": {
-      "geoadj": 0.8687,
       "name": "Congressional District 8 (118th Congress), Wisconsin",
       "median_2br_rent": 981.0
     },
     "5600": {
-      "geoadj": 0.8507,
       "name": "Congressional District (at Large) (118th Congress), Wyoming",
       "median_2br_rent": 932.0
     },
     "0101": {
-      "geoadj": 0.8757,
       "name": "Congressional District 1 (118th Congress), Alabama",
       "median_2br_rent": 1000.0
     },
     "0102": {
-      "geoadj": 0.8312,
       "name": "Congressional District 2 (118th Congress), Alabama",
       "median_2br_rent": 879.0
     },
     "0103": {
-      "geoadj": 0.8132,
       "name": "Congressional District 3 (118th Congress), Alabama",
       "median_2br_rent": 830.0
     },
     "0104": {
-      "geoadj": 0.7768,
       "name": "Congressional District 4 (118th Congress), Alabama",
       "median_2br_rent": 731.0
     },
     "0105": {
-      "geoadj": 0.8507,
       "name": "Congressional District 5 (118th Congress), Alabama",
       "median_2br_rent": 932.0
     },
     "0106": {
-      "geoadj": 0.9423,
       "name": "Congressional District 6 (118th Congress), Alabama",
       "median_2br_rent": 1181.0
     },
     "0107": {
-      "geoadj": 0.8434,
       "name": "Congressional District 7 (118th Congress), Alabama",
       "median_2br_rent": 912.0
     },
     "0200": {
-      "geoadj": 1.0224,
       "name": "Congressional District (at Large) (118th Congress), Alaska",
       "median_2br_rent": 1399.0
     },
     "0401": {
-      "geoadj": 1.132,
       "name": "Congressional District 1 (118th Congress), Arizona",
       "median_2br_rent": 1697.0
     },
     "0402": {
-      "geoadj": 0.9474,
       "name": "Congressional District 2 (118th Congress), Arizona",
       "median_2br_rent": 1195.0
     },
     "0403": {
-      "geoadj": 0.9982,
       "name": "Congressional District 3 (118th Congress), Arizona",
       "median_2br_rent": 1333.0
     },
     "0404": {
-      "geoadj": 1.0934,
       "name": "Congressional District 4 (118th Congress), Arizona",
       "median_2br_rent": 1592.0
     },
     "0405": {
-      "geoadj": 1.1493,
       "name": "Congressional District 5 (118th Congress), Arizona",
       "median_2br_rent": 1744.0
     },
     "0406": {
-      "geoadj": 0.9636,
       "name": "Congressional District 6 (118th Congress), Arizona",
       "median_2br_rent": 1239.0
     },
     "0407": {
-      "geoadj": 0.9,
       "name": "Congressional District 7 (118th Congress), Arizona",
       "median_2br_rent": 1066.0
     },
     "0408": {
-      "geoadj": 1.0621,
       "name": "Congressional District 8 (118th Congress), Arizona",
       "median_2br_rent": 1507.0
     },
     "0409": {
-      "geoadj": 0.9375,
       "name": "Congressional District 9 (118th Congress), Arizona",
       "median_2br_rent": 1168.0
     },
     "0501": {
-      "geoadj": 0.7981,
       "name": "Congressional District 1 (118th Congress), Arkansas",
       "median_2br_rent": 789.0
     },
     "0502": {
-      "geoadj": 0.8584,
       "name": "Congressional District 2 (118th Congress), Arkansas",
       "median_2br_rent": 953.0
     },
     "0503": {
-      "geoadj": 0.8588,
       "name": "Congressional District 3 (118th Congress), Arkansas",
       "median_2br_rent": 954.0
     },
     "0504": {
-      "geoadj": 0.7908,
       "name": "Congressional District 4 (118th Congress), Arkansas",
       "median_2br_rent": 769.0
     },
     "0601": {
-      "geoadj": 0.9526,
       "name": "Congressional District 1 (118th Congress), California",
       "median_2br_rent": 1209.0
     },
     "0602": {
-      "geoadj": 1.2206,
       "name": "Congressional District 2 (118th Congress), California",
       "median_2br_rent": 1938.0
     },
     "0603": {
-      "geoadj": 1.1798,
       "name": "Congressional District 3 (118th Congress), California",
       "median_2br_rent": 1827.0
     },
     "0604": {
-      "geoadj": 1.2508,
       "name": "Congressional District 4 (118th Congress), California",
       "median_2br_rent": 2020.0
     },
     "0605": {
-      "geoadj": 1.0673,
       "name": "Congressional District 5 (118th Congress), California",
       "median_2br_rent": 1521.0
     },
     "0606": {
-      "geoadj": 1.1217,
       "name": "Congressional District 6 (118th Congress), California",
       "median_2br_rent": 1669.0
     },
     "0607": {
-      "geoadj": 1.1236,
       "name": "Congressional District 7 (118th Congress), California",
       "median_2br_rent": 1674.0
     },
     "0608": {
-      "geoadj": 1.2633,
       "name": "Congressional District 8 (118th Congress), California",
       "median_2br_rent": 2054.0
     },
     "0609": {
-      "geoadj": 1.0555,
       "name": "Congressional District 9 (118th Congress), California",
       "median_2br_rent": 1489.0
     },
     "0610": {
-      "geoadj": 1.446,
       "name": "Congressional District 10 (118th Congress), California",
       "median_2br_rent": 2551.0
     },
     "0611": {
-      "geoadj": 1.5,
       "name": "Congressional District 11 (118th Congress), California",
       "median_2br_rent": 3051.0
     },
     "0612": {
-      "geoadj": 1.3497,
       "name": "Congressional District 12 (118th Congress), California",
       "median_2br_rent": 2289.0
     },
     "0613": {
-      "geoadj": 0.9445,
       "name": "Congressional District 13 (118th Congress), California",
       "median_2br_rent": 1187.0
     },
     "0614": {
-      "geoadj": 1.4666,
       "name": "Congressional District 14 (118th Congress), California",
       "median_2br_rent": 2607.0
     },
     "0615": {
-      "geoadj": 1.5,
       "name": "Congressional District 15 (118th Congress), California",
       "median_2br_rent": 3103.0
     },
     "0616": {
-      "geoadj": 1.5,
       "name": "Congressional District 16 (118th Congress), California",
       "median_2br_rent": 2870.0
     },
     "0617": {
-      "geoadj": 1.5,
       "name": "Congressional District 17 (118th Congress), California",
       "median_2br_rent": 3130.0
     },
     "0618": {
-      "geoadj": 1.2714,
       "name": "Congressional District 18 (118th Congress), California",
       "median_2br_rent": 2076.0
     },
     "0619": {
-      "geoadj": 1.3519,
       "name": "Congressional District 19 (118th Congress), California",
       "median_2br_rent": 2295.0
     },
     "0620": {
-      "geoadj": 0.9956,
       "name": "Congressional District 20 (118th Congress), California",
       "median_2br_rent": 1326.0
     },
     "0621": {
-      "geoadj": 0.9316,
       "name": "Congressional District 21 (118th Congress), California",
       "median_2br_rent": 1152.0
     },
     "0622": {
-      "geoadj": 0.8996,
       "name": "Congressional District 22 (118th Congress), California",
       "median_2br_rent": 1065.0
     },
     "0623": {
-      "geoadj": 1.0,
       "name": "Congressional District 23 (118th Congress), California",
       "median_2br_rent": 1338.0
     },
     "0624": {
-      "geoadj": 1.2695,
       "name": "Congressional District 24 (118th Congress), California",
       "median_2br_rent": 2071.0
     },
     "0625": {
-      "geoadj": 0.9684,
       "name": "Congressional District 25 (118th Congress), California",
       "median_2br_rent": 1252.0
     },
     "0626": {
-      "geoadj": 1.3225,
       "name": "Congressional District 26 (118th Congress), California",
       "median_2br_rent": 2215.0
     },
     "0627": {
-      "geoadj": 1.2203,
       "name": "Congressional District 27 (118th Congress), California",
       "median_2br_rent": 1937.0
     },
     "0628": {
-      "geoadj": 1.289,
       "name": "Congressional District 28 (118th Congress), California",
       "median_2br_rent": 2124.0
     },
     "0629": {
-      "geoadj": 1.2545,
       "name": "Congressional District 29 (118th Congress), California",
       "median_2br_rent": 2030.0
     },
     "0630": {
-      "geoadj": 1.3894,
       "name": "Congressional District 30 (118th Congress), California",
       "median_2br_rent": 2397.0
     },
     "0631": {
-      "geoadj": 1.2103,
       "name": "Congressional District 31 (118th Congress), California",
       "median_2br_rent": 1910.0
     },
     "0632": {
-      "geoadj": 1.4291,
       "name": "Congressional District 32 (118th Congress), California",
       "median_2br_rent": 2505.0
     },
     "0633": {
-      "geoadj": 1.0923,
       "name": "Congressional District 33 (118th Congress), California",
       "median_2br_rent": 1589.0
     },
     "0634": {
-      "geoadj": 1.1842,
       "name": "Congressional District 34 (118th Congress), California",
       "median_2br_rent": 1839.0
     },
     "0635": {
-      "geoadj": 1.1982,
       "name": "Congressional District 35 (118th Congress), California",
       "median_2br_rent": 1877.0
     },
     "0636": {
-      "geoadj": 1.5,
       "name": "Congressional District 36 (118th Congress), California",
       "median_2br_rent": 2835.0
     },
     "0637": {
-      "geoadj": 1.1967,
       "name": "Congressional District 37 (118th Congress), California",
       "median_2br_rent": 1873.0
     },
     "0638": {
-      "geoadj": 1.2188,
       "name": "Congressional District 38 (118th Congress), California",
       "median_2br_rent": 1933.0
     },
     "0639": {
-      "geoadj": 1.1647,
       "name": "Congressional District 39 (118th Congress), California",
       "median_2br_rent": 1786.0
     },
     "0640": {
-      "geoadj": 1.4427,
       "name": "Congressional District 40 (118th Congress), California",
       "median_2br_rent": 2542.0
     },
     "0641": {
-      "geoadj": 1.171,
       "name": "Congressional District 41 (118th Congress), California",
       "median_2br_rent": 1803.0
     },
     "0642": {
-      "geoadj": 1.1975,
       "name": "Congressional District 42 (118th Congress), California",
       "median_2br_rent": 1875.0
     },
     "0643": {
-      "geoadj": 1.1688,
       "name": "Congressional District 43 (118th Congress), California",
       "median_2br_rent": 1797.0
     },
     "0644": {
-      "geoadj": 1.1699,
       "name": "Congressional District 44 (118th Congress), California",
       "median_2br_rent": 1800.0
     },
     "0645": {
-      "geoadj": 1.3004,
       "name": "Congressional District 45 (118th Congress), California",
       "median_2br_rent": 2155.0
     },
     "0646": {
-      "geoadj": 1.2861,
       "name": "Congressional District 46 (118th Congress), California",
       "median_2br_rent": 2116.0
     },
     "0647": {
-      "geoadj": 1.5,
       "name": "Congressional District 47 (118th Congress), California",
       "median_2br_rent": 2789.0
     },
     "0648": {
-      "geoadj": 1.2306,
       "name": "Congressional District 48 (118th Congress), California",
       "median_2br_rent": 1965.0
     },
     "0649": {
-      "geoadj": 1.4015,
       "name": "Congressional District 49 (118th Congress), California",
       "median_2br_rent": 2430.0
     },
     "0650": {
-      "geoadj": 1.4126,
       "name": "Congressional District 50 (118th Congress), California",
       "median_2br_rent": 2460.0
     },
     "0651": {
-      "geoadj": 1.3365,
       "name": "Congressional District 51 (118th Congress), California",
       "median_2br_rent": 2253.0
     },
     "0652": {
-      "geoadj": 1.1971,
       "name": "Congressional District 52 (118th Congress), California",
       "median_2br_rent": 1874.0
     },
     "0801": {
-      "geoadj": 1.228,
       "name": "Congressional District 1 (118th Congress), Colorado",
       "median_2br_rent": 1958.0
     },
     "0802": {
-      "geoadj": 1.1669,
       "name": "Congressional District 2 (118th Congress), Colorado",
       "median_2br_rent": 1792.0
     },
     "0803": {
-      "geoadj": 0.9158,
       "name": "Congressional District 3 (118th Congress), Colorado",
       "median_2br_rent": 1109.0
     },
     "0804": {
-      "geoadj": 1.1324,
       "name": "Congressional District 4 (118th Congress), Colorado",
       "median_2br_rent": 1698.0
     },
     "0805": {
-      "geoadj": 1.0596,
       "name": "Congressional District 5 (118th Congress), Colorado",
       "median_2br_rent": 1500.0
     },
     "0806": {
-      "geoadj": 1.1905,
       "name": "Congressional District 6 (118th Congress), Colorado",
       "median_2br_rent": 1856.0
     },
     "0807": {
-      "geoadj": 1.1636,
       "name": "Congressional District 7 (118th Congress), Colorado",
       "median_2br_rent": 1783.0
     },
     "0808": {
-      "geoadj": 1.1088,
       "name": "Congressional District 8 (118th Congress), Colorado",
       "median_2br_rent": 1634.0
     },
     "0901": {
-      "geoadj": 1.039,
       "name": "Congressional District 1 (118th Congress), Connecticut",
       "median_2br_rent": 1444.0
     },
     "0902": {
-      "geoadj": 1.0324,
       "name": "Congressional District 2 (118th Congress), Connecticut",
       "median_2br_rent": 1426.0
     },
     "0903": {
-      "geoadj": 1.078,
       "name": "Congressional District 3 (118th Congress), Connecticut",
       "median_2br_rent": 1550.0
     },
     "0904": {
-      "geoadj": 1.2217,
       "name": "Congressional District 4 (118th Congress), Connecticut",
       "median_2br_rent": 1941.0
     },
     "0905": {
-      "geoadj": 1.0096,
       "name": "Congressional District 5 (118th Congress), Connecticut",
       "median_2br_rent": 1364.0
     }

--- a/spm_calculator/geoadj.py
+++ b/spm_calculator/geoadj.py
@@ -154,15 +154,18 @@ def get_cd_geoadj(
     cd_str = _normalize_cd_geoid(cd_geoid, cds)
     entry = cds[cd_str]
 
-    if "median_2br_rent" in entry:
-        return calculate_geoadj_from_rent(
-            entry["median_2br_rent"],
-            data["national_median_2br_rent"],
-            tenure=tenure,
+    if "median_2br_rent" not in entry:
+        raise ValueError(
+            f"Bundled CD entry for {cd_str} is missing 'median_2br_rent'. "
+            "This should never happen for the 118th-Congress bundle; "
+            "regenerate the JSON from ACS Table B25031 or open an issue."
         )
 
-    # Backward-compatible fallback for older bundled files.
-    return entry["geoadj"]
+    return calculate_geoadj_from_rent(
+        entry["median_2br_rent"],
+        data["national_median_2br_rent"],
+        tenure=tenure,
+    )
 
 
 def get_cd_geoadj_batch(

--- a/tests/test_geoadj.py
+++ b/tests/test_geoadj.py
@@ -154,12 +154,73 @@ class TestGeoAdjLookupTable:
 class TestBundledCDData:
     """Test bundled congressional district data derived from ACS rents."""
 
+    def test_bundled_cd_json_has_no_legacy_geoadj_field(self):
+        """Every bundled CD entry must carry `median_2br_rent` and must
+        *not* carry a precomputed `geoadj`. The precomputed field was
+        baked with the old single housing-share constant (0.492) and
+        was only ever a dead fallback in the runtime lookup; shipping
+        it invites a future maintainer to trust it over the tenure-
+        specific recomputation."""
+        import json
+        from pathlib import Path
+
+        data_path = (
+            Path(__file__).resolve().parent.parent
+            / "spm_calculator"
+            / "data"
+            / "cd_geoadj_2023.json"
+        )
+        with open(data_path) as f:
+            data = json.load(f)
+
+        cds = data["congressional_districts"]
+        assert cds, "Expected bundled CD entries"
+        missing_rent = [
+            cd for cd, entry in cds.items() if "median_2br_rent" not in entry
+        ]
+        leftover_geoadj = [
+            cd for cd, entry in cds.items() if "geoadj" in entry
+        ]
+        assert (
+            not missing_rent
+        ), f"Entries without median_2br_rent: {missing_rent[:5]}"
+        assert not leftover_geoadj, (
+            f"Legacy precomputed geoadj still present in: "
+            f"{leftover_geoadj[:5]}"
+        )
+
     def test_get_cd_geoadj_basic(self):
         from spm_calculator import get_cd_geoadj
 
         result = get_cd_geoadj("612", tenure="renter")
         assert result > 1.2
         assert result <= 1.5
+
+    def test_get_cd_geoadj_raises_on_entry_missing_rent(self, monkeypatch):
+        """Runtime lookup must raise rather than silently fall back
+        when an entry lacks `median_2br_rent`."""
+        from spm_calculator import geoadj as geoadj_module
+
+        # Clear the lru_cache before monkeypatching so the patched
+        # function is actually consulted (and because the lambda
+        # replacement doesn't carry cache_clear itself).
+        geoadj_module._load_bundled_cd_data.cache_clear()
+
+        fake_data = {
+            "year": 2023,
+            "national_median_2br_rent": 1338.0,
+            "congressional_districts": {
+                "999": {"name": "Test District"},  # no median_2br_rent
+            },
+        }
+        monkeypatch.setattr(
+            geoadj_module,
+            "_load_bundled_cd_data",
+            lambda year=2023: fake_data,
+        )
+
+        with pytest.raises(ValueError, match="missing 'median_2br_rent'"):
+            geoadj_module.get_cd_geoadj("999", tenure="renter")
 
     def test_get_cd_geoadj_is_tenure_specific(self):
         from spm_calculator import get_cd_geoadj
@@ -227,9 +288,15 @@ class TestBundledCDData:
         data = get_bundled_cd_data()
         cd_612 = data["congressional_districts"]["612"]
 
-        assert "geoadj" in cd_612
+        # Entries carry name + median_2br_rent only; the runtime
+        # lookup recomputes geoadj from the rent with tenure-specific
+        # shares. A precomputed `geoadj` field used to ship but was
+        # baked with the old single housing-share constant and has
+        # been removed; any new occurrence of that key would be a
+        # regression.
         assert "name" in cd_612
         assert "median_2br_rent" in cd_612
+        assert "geoadj" not in cd_612
 
     def test_invalid_year_raises(self):
         from spm_calculator import get_cd_geoadj


### PR DESCRIPTION
Closes #9.

## Summary

Every entry in `spm_calculator/data/cd_geoadj_2023.json` used to carry a precomputed `geoadj` field alongside `median_2br_rent` and `name`. That value was baked with the old single housing-share constant (0.492) and has been dead code since PR #5 introduced tenure-specific shares — `get_cd_geoadj` reads `median_2br_rent` and recomputes at call time with `calculate_geoadj_from_rent`, ignoring the precomputed field entirely.

Shipping the dead field is a future-maintainer trap: someone reading the JSON will see three-decimal-place values that disagree with what the runtime returns, and may "fix" the runtime to match the stale data.

## Changes

- Strip `geoadj` from all 522 bundled CD entries in `cd_geoadj_2023.json`. Every entry still has `name` and `median_2br_rent`, which is all the runtime needs.
- Replace the legacy fallback `return entry["geoadj"]` in `spm_calculator/geoadj.py::get_cd_geoadj` with a `ValueError` when `median_2br_rent` is missing. Any future bundle lacking rent data now fails loudly instead of silently returning a value inconsistent with the rest of the API.
- Update the existing `test_get_bundled_cd_data_cd_structure` to assert the field's absence, plus two regression tests:
  - JSON-structure guard confirming no shipped entry has leftover `geoadj` or missing `median_2br_rent`
  - Monkeypatched test confirming the new `ValueError` path
- Drop the stale "Values are clamped to the range [0.70, 1.50]" note from `spm_calculator/data/README.md` (the clamp was removed in v0.2.0 with the single housing share)
- Bump to `0.2.2`

## Test plan

- [x] `pytest tests/` → 87 passed, 16 skipped (up from 85 / 16)
- [x] Fresh wheel install reports `__version__ == 0.2.2`
- [x] Bundled CD entry keys: `['median_2br_rent', 'name']` only
- [x] `get_cd_geoadj("612", tenure="renter")` → 1.3149 (CA-12 renter, rent index 2289/1338 × 0.443 + 0.557)

## Related follow-ups (still open)

- #7 — re-weight FCSUti CPI from annual CE shares (blocked on CE expenditure-share data access)
- #8 — verify MRTPRIN and INFOTECH scope against BLS CSX (blocked on BLS CE dictionary access; BLS returns 403 to unauthenticated requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)