### PR TITLE
v0.3.0: derive FCSUti CPI weights from the CE sample

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spm-calculator"
-version = "0.2.2"
+version = "0.3.0"
 description = "Calculate SPM (Supplemental Poverty Measure) thresholds for any US geography and year"
 readme = "README.md"
 license = "MIT"

--- a/spm_calculator/__init__.py
+++ b/spm_calculator/__init__.py
@@ -27,7 +27,12 @@ Get the pieces separately:
 from .calculator import SPMCalculator, spm_threshold
 from .ce_threshold import calculate_base_thresholds, get_published_thresholds
 from .equivalence_scale import spm_equivalence_scale
-from .fcsuti_cpi import get_fcsuti_cpi, get_fcsuti_inflation_factor
+from .fcsuti_cpi import (
+    FCSUTI_WEIGHTS,
+    compute_fcsuti_weights_from_ce,
+    get_fcsuti_cpi,
+    get_fcsuti_inflation_factor,
+)
 from .forecast import (
     HISTORICAL_THRESHOLDS,
     forecast_thresholds,
@@ -87,6 +92,8 @@ __all__ = [
     "spm_equivalence_scale",
     "get_fcsuti_cpi",
     "get_fcsuti_inflation_factor",
+    "compute_fcsuti_weights_from_ce",
+    "FCSUTI_WEIGHTS",
     "forecast_thresholds",
     "get_thresholds",
     "get_threshold_with_metadata",

--- a/spm_calculator/ce_threshold.py
+++ b/spm_calculator/ce_threshold.py
@@ -28,7 +28,10 @@ import pandas as pd
 import requests
 
 from .equivalence_scale import REFERENCE_RAW_SCALE, spm_equivalence_scale
-from .fcsuti_cpi import get_fcsuti_inflation_factor
+from .fcsuti_cpi import (
+    compute_fcsuti_weights_from_ce,
+    get_fcsuti_inflation_factor,
+)
 
 # BLS CE Survey PUMD base URL
 CE_PUMD_BASE_URL = "https://www.bls.gov/cex/pumd/data/comma"
@@ -302,10 +305,29 @@ def calculate_base_thresholds(
 
         ce["fcsuti"] = calculate_fcsuti(ce)
 
+        # Derive FCSUti composite weights from this CE sample itself,
+        # matching BLS Garner (2021): the weights roll with the 5-year
+        # window rather than being held static across years. Fall back
+        # to the package default (with its own RuntimeWarning) only if
+        # the CE sample has no usable expenditure columns.
+        try:
+            fcsuti_weights = compute_fcsuti_weights_from_ce(ce)
+        except ValueError as e:
+            warnings.warn(
+                f"Could not derive FCSUti weights from CE ({e}); "
+                "using static defaults.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            fcsuti_weights = None
+
         # Inflate each CU's FCSUti to target-year dollars using the
-        # FCSUti composite CPI.
+        # FCSUti composite CPI built from the derived (or default)
+        # weights.
         inflation_factors = {
-            year: get_fcsuti_inflation_factor(year, target_year)
+            year: get_fcsuti_inflation_factor(
+                year, target_year, weights=fcsuti_weights
+            )
             for year in ce["ce_year"].dropna().astype(int).unique()
         }
         ce["inflation_factor"] = (

--- a/spm_calculator/fcsuti_cpi.py
+++ b/spm_calculator/fcsuti_cpi.py
@@ -205,23 +205,29 @@ def compute_fcsuti_weights_from_ce(
     return {component: value / total for component, value in totals.items()}
 
 
+_STATIC_WEIGHTS_WARNING = (
+    "Using static FCSUti weights approximation. For BLS-fidelity "
+    "inflation adjustment, derive weights from the CE sample via "
+    "compute_fcsuti_weights_from_ce() or supply an explicit "
+    "weights= dict keyed by component name."
+)
+
+
 def _resolve_weights(
     weights: Optional[Mapping[str, float]],
 ) -> dict[str, float]:
-    """Return effective weights, warning when the static fallback is used."""
-    if weights is not None:
-        if not weights:
-            raise ValueError("weights mapping is empty")
-        return dict(weights)
-    warnings.warn(
-        "Using static FCSUti weights approximation. For BLS-fidelity "
-        "inflation adjustment, derive weights from the CE sample via "
-        "compute_fcsuti_weights_from_ce() or supply an explicit "
-        "weights= dict keyed by component name.",
-        RuntimeWarning,
-        stacklevel=3,
-    )
-    return dict(FCSUTI_WEIGHTS)
+    """Normalize a supplied ``weights`` mapping (never warns).
+
+    The fallback-use RuntimeWarning is emitted by the public
+    entry-point functions (``get_fcsuti_cpi``,
+    ``get_fcsuti_inflation_factor``) so that ``stacklevel=2`` attributes
+    the warning to the user regardless of which entry point is called.
+    """
+    if weights is None:
+        return dict(FCSUTI_WEIGHTS)
+    if not weights:
+        raise ValueError("weights mapping is empty")
+    return dict(weights)
 
 
 @lru_cache(maxsize=8)
@@ -302,6 +308,12 @@ def get_fcsuti_cpi(
     Returns:
         Annual FCSUti CPI index with base ``base_year`` = 100.
     """
+    if weights is None:
+        warnings.warn(
+            _STATIC_WEIGHTS_WARNING,
+            RuntimeWarning,
+            stacklevel=2,
+        )
     resolved = _resolve_weights(weights)
     return _cached_fcsuti_cpi(
         start_year,
@@ -329,6 +341,13 @@ def get_fcsuti_inflation_factor(
         dollars. Falls back to a ~4%/yr estimate if the BLS series
         fetch fails, and emits a :class:`RuntimeWarning` in that case.
     """
+    if weights is None:
+        warnings.warn(
+            _STATIC_WEIGHTS_WARNING,
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        weights = FCSUTI_WEIGHTS
     try:
         fcsuti = get_fcsuti_cpi(
             start_year=min(from_year, to_year) - 1,

--- a/spm_calculator/fcsuti_cpi.py
+++ b/spm_calculator/fcsuti_cpi.py
@@ -1,30 +1,37 @@
-"""
-FCSUti CPI-U Composite Index calculation.
+"""FCSUti CPI-U Composite Index for SPM threshold inflation adjustment.
 
-The FCSUti (Food, Clothing, Shelter, Utilities, telephone, internet) price
-index is used to adjust CE expenditure data to threshold-year dollars.
+The FCSUti composite re-weights five CPI-U component series (food, apparel,
+shelter, utilities, telephone, and — for post-2018 vintages — internet) in
+proportion to the FCSUti expenditure shares of consumer units with children.
+It replaces the All-Items CPI-U used in the pre-2021 SPM methodology.
 
-This replaces the All Items CPI-U that was used in earlier SPM methodology.
+BLS re-derives the component weights from the CE expenditure sample used
+for the target-year threshold itself, so the weights roll with the 5-year
+lagged window. This module supports three ways of supplying weights:
 
-Components and approximate weights (based on CE expenditure shares):
-- Food (at home + away): ~30%
-- Apparel: ~5%
-- Shelter: ~45%
-- Utilities (fuel and utilities): ~12%
-- Telephone and internet services: ~8%
+1. Pass a ``weights`` dict explicitly (highest precedence).
+2. Compute weights from a CE FMLI DataFrame with
+   :func:`compute_fcsuti_weights_from_ce`.
+3. Fall back to :data:`FCSUTI_WEIGHTS`, a static approximation. A
+   :class:`RuntimeWarning` is emitted in this case so runs using the
+   fallback are visible in logs.
 
-Reference:
-- BLS SPM Thresholds methodology
-- https://www.bls.gov/pir/spm/spm_thresholds_2024.htm
+References
+----------
+- Garner, T. (2021). *Alternative Measures of the Extent and Severity
+  of Poverty: A Review and Data Users' Guide to the Supplemental
+  Poverty Measure.* BLS, https://www.bls.gov/pir/spm/garner_spm_choices_03_15_21.pdf
+- BLS SPM Thresholds: https://www.bls.gov/pir/spm/spm_thresholds_2024.htm
 """
 
 import warnings
 from functools import lru_cache
-from typing import Optional
+from typing import Mapping, Optional
 
+import numpy as np
 import pandas as pd
 
-# BLS CPI series IDs for FCSUti components
+# BLS CPI series IDs for FCSUti components.
 # Source: https://www.bls.gov/cpi/data.htm
 CPI_SERIES = {
     "food": "CUUR0000SAF",  # Food
@@ -34,14 +41,16 @@ CPI_SERIES = {
     "shelter": "CUUR0000SAH1",  # Shelter
     "utilities": "CUUR0000SAH2",  # Fuels and utilities
     "telephone": "CUUR0000SEED",  # Telephone services
-    "internet": "CUUR0000SEEE",  # Internet services and electronic info
-    "all_items": "CUUR0000SA0",  # All items (for reference)
+    "internet": "CUUR0000SEEE",  # Internet services
+    "all_items": "CUUR0000SA0",  # All items (reference only)
 }
 
-# Approximate expenditure weights for FCSUti composite
-# These are based on CE Survey expenditure shares for consumer units with children
-# Weights should sum to 1.0
-FCSUTI_WEIGHTS = {
+# Static fallback FCSUti expenditure shares for consumer units with
+# children. These are a rough approximation of CE shares; BLS re-derives
+# them annually from the 5-year CE sample used for each threshold year.
+# Prefer supplying ``weights=`` explicitly or deriving via
+# :func:`compute_fcsuti_weights_from_ce`.
+FCSUTI_WEIGHTS: dict[str, float] = {
     "food": 0.30,
     "apparel": 0.05,
     "shelter": 0.45,
@@ -50,156 +59,296 @@ FCSUTI_WEIGHTS = {
     "internet": 0.04,
 }
 
+# FMLI expenditure-column pairs (PQ = previous quarter, CQ = current
+# quarter) for each FCSUti component. Used by
+# :func:`compute_fcsuti_weights_from_ce`.
+_FMLI_EXPENDITURE_COLUMNS: dict[str, tuple[str, str]] = {
+    "food": ("FOODPQ", "FOODCQ"),
+    "apparel": ("APPARPQ", "APPARCQ"),
+    "shelter": ("SHELTPQ", "SHELTCQ"),
+    "utilities": ("UTILPQ", "UTILCQ"),
+    "telephone": ("TELEPHPQ", "TELEPHCQ"),
+    "internet": ("INFOTECHPQ", "INFOTECHCQ"),
+}
+
+_MORTGAGE_PRINCIPAL_COLUMNS: tuple[str, str] = ("MRTPRINPQ", "MRTPRINCQ")
+
 
 def fetch_bls_cpi_series(
     series_id: str,
     start_year: int = 2010,
     end_year: int = 2024,
 ) -> pd.Series:
-    """
-    Fetch CPI series data from BLS API.
+    """Fetch an annual-average CPI series from the BLS public API.
 
     Args:
-        series_id: BLS series ID (e.g., "CUUR0000SA0")
-        start_year: Start year for data
-        end_year: End year for data
+        series_id: BLS series ID (e.g. ``"CUUR0000SA0"``).
+        start_year: Inclusive start year.
+        end_year: Inclusive end year.
 
     Returns:
-        Series with annual average CPI values indexed by year
+        Series of annual-average CPI values indexed by calendar year.
     """
     import requests
 
-    # BLS Public Data API (no registration required for small requests)
     url = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
-
     payload = {
         "seriesid": [series_id],
         "startyear": str(start_year),
         "endyear": str(end_year),
         "annualaverage": True,
     }
-
     response = requests.post(url, json=payload, timeout=30)
     response.raise_for_status()
-
     data = response.json()
-
     if data["status"] != "REQUEST_SUCCEEDED":
         raise ValueError(
             f"BLS API error: {data.get('message', 'Unknown error')}"
         )
 
-    # Extract annual averages
     series_data = data["Results"]["series"][0]["data"]
-
-    # Filter to annual averages (period = "M13")
+    # Filter to annual averages (period code M13).
     annual = [d for d in series_data if d["period"] == "M13"]
-
-    result = pd.Series(
+    return pd.Series(
         {int(d["year"]): float(d["value"]) for d in annual},
         name=series_id,
     ).sort_index()
 
-    return result
+
+def compute_fcsuti_weights_from_ce(
+    ce_df: pd.DataFrame,
+    weight_col: str = "FINLWT21",
+    children_col: str = "PERSLT18",
+    subtract_mortgage_principal: bool = True,
+) -> dict[str, float]:
+    """Derive FCSUti expenditure shares from a CE FMLI DataFrame.
+
+    For each FCSUti component, computes the survey-weighted total
+    expenditure across consumer units with at least one child, then
+    normalizes so the returned shares sum to 1.0. Matches the BLS
+    Garner (2021) methodology where the composite weights are derived
+    from the same CE sample used to compute the threshold itself.
+
+    The ``shelter`` component follows the SPM convention of excluding
+    mortgage principal (investment, not consumption) when the
+    ``MRTPRINPQ``/``MRTPRINCQ`` columns are present.
+
+    Args:
+        ce_df: CE FMLI DataFrame (one row per CU-interview).
+        weight_col: Column with the CU's calibrated survey weight.
+            Defaults to ``FINLWT21`` (standard FMLI name).
+        children_col: Column with the number of persons under 18 in
+            the CU. Defaults to ``PERSLT18``.
+        subtract_mortgage_principal: When True (default) and
+            ``MRTPRINPQ``/``MRTPRINCQ`` are in ``ce_df``, subtract
+            mortgage principal from shelter expenditure.
+
+    Returns:
+        Dict mapping each FCSUti component present in ``ce_df`` to a
+        share in ``[0, 1]``. Shares sum to 1.0. Components without
+        their expenditure columns in the data are omitted.
+
+    Raises:
+        ValueError: If ``ce_df`` is missing ``weight_col`` or
+            ``children_col``, or if no CUs have children, or if no
+            FCSUti component columns are present.
+    """
+    if weight_col not in ce_df.columns:
+        raise ValueError(
+            f"CE DataFrame is missing weight column '{weight_col}'"
+        )
+    if children_col not in ce_df.columns:
+        raise ValueError(
+            f"CE DataFrame is missing children column '{children_col}'"
+        )
+
+    with_children = ce_df[ce_df[children_col] > 0]
+    if len(with_children) == 0:
+        raise ValueError("No consumer units with children in CE DataFrame")
+
+    weights = with_children[weight_col].astype(float).to_numpy()
+
+    def _weighted_expenditure(pq: str, cq: str) -> Optional[float]:
+        if pq not in with_children.columns or cq not in with_children.columns:
+            return None
+        values = (
+            with_children[pq].fillna(0).to_numpy()
+            + with_children[cq].fillna(0).to_numpy()
+        )
+        return float(np.sum(values * weights))
+
+    shelter_principal_offset: Optional[float] = None
+    if subtract_mortgage_principal:
+        shelter_principal_offset = _weighted_expenditure(
+            *_MORTGAGE_PRINCIPAL_COLUMNS
+        )
+
+    totals: dict[str, float] = {}
+    for component, (pq, cq) in _FMLI_EXPENDITURE_COLUMNS.items():
+        exp = _weighted_expenditure(pq, cq)
+        if exp is None:
+            continue
+        if component == "shelter" and shelter_principal_offset is not None:
+            exp = max(exp - shelter_principal_offset, 0.0)
+        totals[component] = exp
+
+    if not totals:
+        raise ValueError(
+            "CE DataFrame has no FCSUti expenditure columns "
+            f"({list(_FMLI_EXPENDITURE_COLUMNS)})"
+        )
+
+    total = sum(totals.values())
+    if total <= 0:
+        raise ValueError("Total FCSUti expenditure is zero or negative")
+
+    return {component: value / total for component, value in totals.items()}
+
+
+def _resolve_weights(
+    weights: Optional[Mapping[str, float]],
+) -> dict[str, float]:
+    """Return effective weights, warning when the static fallback is used."""
+    if weights is not None:
+        if not weights:
+            raise ValueError("weights mapping is empty")
+        return dict(weights)
+    warnings.warn(
+        "Using static FCSUti weights approximation. For BLS-fidelity "
+        "inflation adjustment, derive weights from the CE sample via "
+        "compute_fcsuti_weights_from_ce() or supply an explicit "
+        "weights= dict keyed by component name.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+    return dict(FCSUTI_WEIGHTS)
 
 
 @lru_cache(maxsize=8)
-def get_fcsuti_cpi(
-    start_year: int = 2010,
-    end_year: int = 2024,
-    base_year: int = 2024,
+def _cached_fcsuti_cpi(
+    start_year: int,
+    end_year: int,
+    base_year: int,
+    weights_items: tuple[tuple[str, float], ...],
 ) -> pd.Series:
-    """
-    Calculate the FCSUti composite CPI index.
-
-    Args:
-        start_year: Start year for index
-        end_year: End year for index
-        base_year: Year to set index = 100
-
-    Returns:
-        Series with FCSUti CPI values indexed by year
-    """
-    components = {}
-
-    # Fetch each component series
-    for component, series_id in CPI_SERIES.items():
-        if component in FCSUTI_WEIGHTS:
-            try:
-                components[component] = fetch_bls_cpi_series(
-                    series_id, start_year, end_year
-                )
-            except Exception as e:
-                warnings.warn(
-                    f"Could not fetch {component} CPI: {e}",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
+    """Immutable-inputs worker for :func:`get_fcsuti_cpi`."""
+    weights = dict(weights_items)
+    components: dict[str, pd.Series] = {}
+    for component in weights:
+        series_id = CPI_SERIES.get(component)
+        if series_id is None:
+            warnings.warn(
+                f"No CPI series known for component '{component}'; skipping.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+        try:
+            components[component] = fetch_bls_cpi_series(
+                series_id, start_year, end_year
+            )
+        except Exception as e:
+            warnings.warn(
+                f"Could not fetch {component} CPI: {e}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     if not components:
         raise ValueError("Could not fetch any CPI component data")
 
-    # Combine into DataFrame
     df = pd.DataFrame(components)
+    used_weights = {c: weights[c] for c in df.columns if c in weights}
+    if not used_weights:
+        raise ValueError(
+            "None of the requested FCSUti components returned CPI data"
+        )
 
-    # Calculate weighted composite
+    denom = sum(used_weights.values())
+    if denom <= 0:
+        raise ValueError("Requested FCSUti weights sum to zero")
+    # Renormalize over the components we actually have so dropped series
+    # don't shrink the composite.
+    renormalized = {c: w / denom for c, w in used_weights.items()}
+
     fcsuti = pd.Series(0.0, index=df.index)
-    total_weight = 0.0
+    for component, weight in renormalized.items():
+        fcsuti += df[component] * weight
 
-    for component, weight in FCSUTI_WEIGHTS.items():
-        if component in df.columns:
-            fcsuti += df[component] * weight
-            total_weight += weight
-
-    # Normalize if we didn't get all components
-    if total_weight < 1.0:
-        fcsuti = fcsuti / total_weight
-
-    # Rebase to base_year = 100
     if base_year in fcsuti.index:
         fcsuti = fcsuti / fcsuti[base_year] * 100
-
     fcsuti.name = "FCSUti CPI-U"
     return fcsuti
+
+
+def get_fcsuti_cpi(
+    start_year: int = 2010,
+    end_year: int = 2024,
+    base_year: int = 2024,
+    weights: Optional[Mapping[str, float]] = None,
+) -> pd.Series:
+    """Compute the FCSUti composite CPI index.
+
+    Args:
+        start_year: Inclusive start year for the index.
+        end_year: Inclusive end year for the index.
+        base_year: Year normalized to 100.
+        weights: Optional component-share mapping (e.g. the output of
+            :func:`compute_fcsuti_weights_from_ce`). When None, falls
+            back to :data:`FCSUTI_WEIGHTS` with a
+            :class:`RuntimeWarning` so callers notice when the static
+            approximation is in use.
+
+    Returns:
+        Annual FCSUti CPI index with base ``base_year`` = 100.
+    """
+    resolved = _resolve_weights(weights)
+    return _cached_fcsuti_cpi(
+        start_year,
+        end_year,
+        base_year,
+        tuple(sorted(resolved.items())),
+    )
 
 
 def get_fcsuti_inflation_factor(
     from_year: int,
     to_year: int,
+    weights: Optional[Mapping[str, float]] = None,
 ) -> float:
-    """
-    Get inflation adjustment factor between two years using FCSUti CPI.
+    """Inflation factor between two years via the FCSUti composite.
 
     Args:
-        from_year: Base year
-        to_year: Target year
+        from_year: Starting year (sets the index base).
+        to_year: Target year.
+        weights: Optional FCSUti component shares. See
+            :func:`get_fcsuti_cpi`.
 
     Returns:
-        Inflation factor (multiply from_year values by this to get to_year values)
+        Factor to multiply ``from_year`` dollars by to get ``to_year``
+        dollars. Falls back to a ~4%/yr estimate if the BLS series
+        fetch fails, and emits a :class:`RuntimeWarning` in that case.
     """
     try:
         fcsuti = get_fcsuti_cpi(
             start_year=min(from_year, to_year) - 1,
             end_year=max(from_year, to_year) + 1,
             base_year=from_year,
+            weights=weights,
         )
         return fcsuti[to_year] / 100.0
     except Exception as e:
-        # Fallback to simple estimate if BLS API unavailable.
-        # Use ~4% annual inflation (recent FCSUti average).
         warnings.warn(
             f"Could not get FCSUti CPI ({e}); falling back to 4%/yr estimate.",
             RuntimeWarning,
             stacklevel=2,
         )
-        years_diff = to_year - from_year
-        return 1.04**years_diff
+        return 1.04 ** (to_year - from_year)
 
 
-# Pre-computed FCSUti inflation factors for common year pairs
-# These can be used when BLS API is unavailable
+# Pre-computed FCSUti inflation factors for common year pairs. Retained
+# for offline use when the BLS API is unavailable.
 PRECOMPUTED_FCSUTI_FACTORS = {
-    # (from_year, to_year): factor
     (2018, 2024): 1.26,  # ~4.0% annual
     (2019, 2024): 1.22,  # ~4.1% annual
     (2020, 2024): 1.19,  # ~4.5% annual (pandemic effects)
@@ -213,9 +362,5 @@ def get_precomputed_fcsuti_factor(
     from_year: int,
     to_year: int,
 ) -> Optional[float]:
-    """
-    Get pre-computed FCSUti inflation factor if available.
-
-    Returns None if not pre-computed.
-    """
+    """Return the pre-computed inflation factor for a year pair, or None."""
     return PRECOMPUTED_FCSUTI_FACTORS.get((from_year, to_year))

--- a/tests/test_base_thresholds.py
+++ b/tests/test_base_thresholds.py
@@ -133,6 +133,16 @@ class TestCEThresholdMethodology:
                 "PERSLT18": [2, 2],
                 "ADULT": [2, 2],
                 "ce_year": [2022, 2023],
+                # FINLWT21 lets compute_fcsuti_weights_from_ce run, but
+                # the stubbed `get_fcsuti_inflation_factor` ignores the
+                # derived weights anyway.
+                "FINLWT21": [1000.0, 1000.0],
+                # Minimal expenditure columns so the weight derivation
+                # has something to normalize (values arbitrary).
+                "FOODPQ": [100.0, 100.0],
+                "FOODCQ": [100.0, 100.0],
+                "SHELTPQ": [300.0, 300.0],
+                "SHELTCQ": [300.0, 300.0],
             }
         )
 
@@ -147,7 +157,10 @@ class TestCEThresholdMethodology:
         monkeypatch.setattr(
             ce_threshold,
             "get_fcsuti_inflation_factor",
-            lambda from_year, to_year: {2022: 2.0, 2023: 1.0}[from_year],
+            lambda from_year, to_year, weights=None: {
+                2022: 2.0,
+                2023: 1.0,
+            }[from_year],
         )
 
         thresholds = ce_threshold.calculate_base_thresholds(

--- a/tests/test_fcsuti_cpi.py
+++ b/tests/test_fcsuti_cpi.py
@@ -1,0 +1,239 @@
+"""Unit tests for the FCSUti CPI module.
+
+Covers the pure-function helpers that run without hitting the BLS API:
+``compute_fcsuti_weights_from_ce`` and the ``weights`` plumbing on the
+composite-CPI builders. End-to-end tests that actually fetch BLS data
+are network-gated in ``test_ce_validation.py``.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from spm_calculator import fcsuti_cpi
+from spm_calculator.fcsuti_cpi import (
+    FCSUTI_WEIGHTS,
+    compute_fcsuti_weights_from_ce,
+    get_fcsuti_cpi,
+    get_fcsuti_inflation_factor,
+)
+
+
+def _sample_ce_df(extra: dict | None = None) -> pd.DataFrame:
+    """Build a synthetic FMLI DataFrame with the columns we care about."""
+    base = {
+        "PERSLT18": [1, 2, 0, 1],
+        "FINLWT21": [100.0, 200.0, 150.0, 50.0],
+        "FOODPQ": [1000.0, 2000.0, 800.0, 500.0],
+        "FOODCQ": [1000.0, 2000.0, 800.0, 500.0],
+        "APPARPQ": [100.0, 200.0, 50.0, 60.0],
+        "APPARCQ": [100.0, 200.0, 50.0, 60.0],
+        "SHELTPQ": [3000.0, 4000.0, 2500.0, 1800.0],
+        "SHELTCQ": [3000.0, 4000.0, 2500.0, 1800.0],
+        "UTILPQ": [500.0, 800.0, 400.0, 300.0],
+        "UTILCQ": [500.0, 800.0, 400.0, 300.0],
+        "TELEPHPQ": [200.0, 250.0, 180.0, 150.0],
+        "TELEPHCQ": [200.0, 250.0, 180.0, 150.0],
+    }
+    if extra:
+        base.update(extra)
+    return pd.DataFrame(base)
+
+
+class TestComputeFcsutiWeightsFromCE:
+    def test_shares_sum_to_one(self):
+        ce = _sample_ce_df()
+        weights = compute_fcsuti_weights_from_ce(ce)
+        assert pytest.approx(sum(weights.values()), rel=1e-12) == 1.0
+
+    def test_restricts_to_consumer_units_with_children(self):
+        """CUs with zero children must not contribute to the shares."""
+        ce = _sample_ce_df()
+        # Flip every CU to childless and watch the function reject the input.
+        ce_childless = ce.assign(PERSLT18=0)
+        with pytest.raises(
+            ValueError, match="No consumer units with children"
+        ):
+            compute_fcsuti_weights_from_ce(ce_childless)
+
+        # Now make one CU (row 2, weight 150) stay childless and keep the
+        # other three. Row 2's expenditures must be excluded from the
+        # share calculation.
+        mixed = ce.copy()
+        with_children_mask = mixed["PERSLT18"] > 0
+        with_children_only = compute_fcsuti_weights_from_ce(
+            mixed[with_children_mask].reset_index(drop=True)
+        )
+        all_rows_weights = compute_fcsuti_weights_from_ce(mixed)
+        assert all_rows_weights == pytest.approx(with_children_only)
+
+    def test_weight_proportional_expenditure(self):
+        """Manually compute expected shares from the synthetic sample."""
+        ce = _sample_ce_df()
+        # Rows with PERSLT18 > 0 are indices 0, 1, 3 with FINLWT21 =
+        # 100, 200, 50. Food PQ+CQ for those rows: 2000, 4000, 1000 ->
+        # weighted sum matches the hand-computed totals below.
+        food = 2000 * 100 + 4000 * 200 + 1000 * 50
+        apparel = 200 * 100 + 400 * 200 + 120 * 50
+        shelter = 6000 * 100 + 8000 * 200 + 3600 * 50
+        util = 1000 * 100 + 1600 * 200 + 600 * 50
+        tele = 400 * 100 + 500 * 200 + 300 * 50
+        total = food + apparel + shelter + util + tele
+
+        weights = compute_fcsuti_weights_from_ce(ce)
+        assert weights["food"] == pytest.approx(food / total)
+        assert weights["apparel"] == pytest.approx(apparel / total)
+        assert weights["shelter"] == pytest.approx(shelter / total)
+        assert weights["utilities"] == pytest.approx(util / total)
+        assert weights["telephone"] == pytest.approx(tele / total)
+
+    def test_subtracts_mortgage_principal_from_shelter(self):
+        """When MRTPRIN columns are present, shelter is net of principal."""
+        ce = _sample_ce_df(
+            {
+                "MRTPRINPQ": [500.0, 1000.0, 200.0, 0.0],
+                "MRTPRINCQ": [500.0, 1000.0, 200.0, 0.0],
+            }
+        )
+        with_subtraction = compute_fcsuti_weights_from_ce(
+            ce, subtract_mortgage_principal=True
+        )
+        without_subtraction = compute_fcsuti_weights_from_ce(
+            ce, subtract_mortgage_principal=False
+        )
+        # Shelter share shrinks when principal is subtracted out.
+        assert with_subtraction["shelter"] < without_subtraction["shelter"]
+        # Other components' shares rise (same numerator, smaller denominator).
+        assert with_subtraction["food"] > without_subtraction["food"]
+
+    def test_includes_internet_when_infotech_columns_present(self):
+        ce = _sample_ce_df(
+            {
+                "INFOTECHPQ": [300.0, 400.0, 200.0, 180.0],
+                "INFOTECHCQ": [300.0, 400.0, 200.0, 180.0],
+            }
+        )
+        weights = compute_fcsuti_weights_from_ce(ce)
+        assert "internet" in weights
+        assert weights["internet"] > 0
+
+    def test_missing_component_column_silently_dropped(self):
+        """If a component's expenditure columns aren't present, the
+        component is omitted from the returned shares rather than
+        treated as zero (and the remaining shares re-normalize)."""
+        ce = _sample_ce_df().drop(columns=["APPARPQ", "APPARCQ"])
+        weights = compute_fcsuti_weights_from_ce(ce)
+        assert "apparel" not in weights
+        assert pytest.approx(sum(weights.values()), rel=1e-12) == 1.0
+
+    def test_missing_weight_column_raises(self):
+        ce = _sample_ce_df().drop(columns=["FINLWT21"])
+        with pytest.raises(ValueError, match="FINLWT21"):
+            compute_fcsuti_weights_from_ce(ce)
+
+    def test_missing_children_column_raises(self):
+        ce = _sample_ce_df().drop(columns=["PERSLT18"])
+        with pytest.raises(ValueError, match="PERSLT18"):
+            compute_fcsuti_weights_from_ce(ce)
+
+    def test_no_expenditure_columns_raises(self):
+        ce = _sample_ce_df().drop(
+            columns=[
+                c
+                for c in _sample_ce_df().columns
+                if c not in {"PERSLT18", "FINLWT21"}
+            ]
+        )
+        with pytest.raises(ValueError, match="FCSUti expenditure"):
+            compute_fcsuti_weights_from_ce(ce)
+
+
+class TestGetFcsutiCpiWeightsPlumbing:
+    def test_static_fallback_emits_runtime_warning(self, monkeypatch):
+        """With no ``weights`` argument, the static default is used and
+        a ``RuntimeWarning`` surfaces in logs."""
+        # Stub out the BLS fetch so the test doesn't touch the network.
+        fake_series = pd.Series(
+            {2020: 100.0, 2021: 105.0, 2022: 112.0}, name="stub"
+        )
+        monkeypatch.setattr(
+            fcsuti_cpi,
+            "fetch_bls_cpi_series",
+            lambda series_id, start_year, end_year: fake_series,
+        )
+        # Clear the cache on the cached helper so our patched fetch is
+        # actually invoked.
+        fcsuti_cpi._cached_fcsuti_cpi.cache_clear()
+
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            cpi = get_fcsuti_cpi(
+                start_year=2020, end_year=2022, base_year=2022
+            )
+        assert cpi[2022] == pytest.approx(100.0)
+        messages = [
+            str(r.message)
+            for r in records
+            if issubclass(r.category, RuntimeWarning)
+        ]
+        assert any(
+            "static FCSUti weights" in m for m in messages
+        ), f"Expected static-weights warning, got: {messages}"
+
+    def test_explicit_weights_suppress_warning(self, monkeypatch):
+        """Supplying ``weights`` explicitly is the opt-in path and
+        should not warn."""
+        fake_series = pd.Series(
+            {2020: 100.0, 2021: 105.0, 2022: 112.0}, name="stub"
+        )
+        monkeypatch.setattr(
+            fcsuti_cpi,
+            "fetch_bls_cpi_series",
+            lambda series_id, start_year, end_year: fake_series,
+        )
+        fcsuti_cpi._cached_fcsuti_cpi.cache_clear()
+
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            get_fcsuti_cpi(
+                start_year=2020,
+                end_year=2022,
+                base_year=2022,
+                weights={"food": 0.5, "shelter": 0.5},
+            )
+        static_warnings = [
+            r for r in records if "static FCSUti weights" in str(r.message)
+        ]
+        assert static_warnings == []
+
+    def test_empty_weights_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            get_fcsuti_cpi(weights={})
+
+    def test_inflation_factor_threads_weights(self, monkeypatch):
+        """get_fcsuti_inflation_factor must forward its ``weights`` arg."""
+        captured = {}
+
+        def _stub(start_year, end_year, base_year, weights=None):
+            captured["weights"] = weights
+            # Caller does fcsuti[to_year] / 100, so 2024 must be in the
+            # index. Emit a window that covers start_year..end_year and
+            # sets 2024 to 120 relative to base_year=100.
+            idx = list(range(start_year, end_year + 1))
+            values = {y: 100.0 for y in idx}
+            values[2024] = 120.0
+            return pd.Series(values)
+
+        monkeypatch.setattr(fcsuti_cpi, "get_fcsuti_cpi", _stub)
+        w = {"food": 1.0}
+        result = get_fcsuti_inflation_factor(2022, 2024, weights=w)
+        assert captured["weights"] == w
+        assert result == pytest.approx(1.2)
+
+
+class TestStaticWeightsShape:
+    def test_defaults_sum_approximately_to_one(self):
+        """The fallback dict is a rough approximation but the shares
+        should still integrate to 1.0 to within normal rounding."""
+        assert sum(FCSUTI_WEIGHTS.values()) == pytest.approx(1.0, abs=0.01)


### PR DESCRIPTION
Closes #7.

## Summary

`fcsuti_cpi.py` previously hardcoded FCSUti CPI-U composite weights. Per Garner (2021), BLS re-derives those shares every year from the same 5-year CE sample that feeds the threshold calculation — shelter share has been rising, so the static dict now under-weights shelter inflation in later years.

This release exposes three ways to supply weights:

1. Explicit `weights=` arg on `get_fcsuti_cpi` / `get_fcsuti_inflation_factor` (highest precedence).
2. New `compute_fcsuti_weights_from_ce(ce_df)` helper that derives shares from an FMLI DataFrame using `FINLWT21` survey weights, restricted to CUs with children, with shelter net of mortgage principal per SPM convention.
3. Fall back to the static `FCSUTI_WEIGHTS` dict — now emits a `RuntimeWarning` so runs using the approximation are visible.

`ce_threshold.calculate_base_thresholds` is rewired to derive weights from the CE sample it already downloaded and pass them into the FCSUti CPI calculation, matching BLS's rolling-window methodology. When the expenditure columns are missing (e.g. very old vintages), it falls back to the static dict with a clear warning trail.

## Test plan

- [x] `pytest tests/` → **101 passed, 16 skipped** (up from 87 / 16)
- [x] Wheel install: `__version__ == "0.3.0"`; `spm_threshold(2,2,metro='San Jose')` still returns 59815
- [x] `bun run build` on `web/` unaffected (no web changes)

## Coverage additions (+14 tests in `tests/test_fcsuti_cpi.py`)

- `compute_fcsuti_weights_from_ce`:
  - Shares sum to 1.0 across all code paths
  - CUs without children are excluded from weight derivation
  - Hand-computed sample (3 CUs with children) verifies the weighted expenditure totals line up
  - `subtract_mortgage_principal=True` shrinks shelter share and raises other shares proportionally
  - `INFOTECHPQ/CQ` columns bring internet into the shares when present
  - Missing expenditure columns are silently dropped with re-normalization; missing weight/children columns raise
- `get_fcsuti_cpi` / `get_fcsuti_inflation_factor`:
  - Static fallback emits `RuntimeWarning`; explicit weights suppress it
  - Inflation factor correctly forwards the `weights` arg through
- `FCSUTI_WEIGHTS` dict integrates to ~1.0

## Compatibility

Public API strictly expands. Old callers keep working — they just start seeing a new `RuntimeWarning` about the static fallback. No breaking changes.

## Remaining v0.3 follow-up (#8)

MRTPRIN and INFOTECH scope still need verification against the BLS CE CSX dictionary before the CE recomputation can claim full BLS fidelity. Blocked on CSX access (BLS returns 403 to unauthenticated requests). Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)