### PR TITLE
Reject child-only and negative-count SPM unit inputs on every path

### DIFF
--- a/spm_calculator/calculator.py
+++ b/spm_calculator/calculator.py
@@ -21,6 +21,30 @@ from .geoadj import (
 )
 
 
+def _validate_household_composition(
+    num_adults: Union[int, np.ndarray],
+    num_children: Union[int, np.ndarray],
+) -> None:
+    """Reject obviously-impossible SPM unit compositions.
+
+    SPM units are headed by a reference person aged 15+, so every unit has
+    at least one adult. Negative counts are meaningless. Both scalar and
+    batch paths share this guard so `calculate_thresholds` can't silently
+    emit zero for a child-only row the scalar API would have raised on.
+    """
+    adults = np.asarray(num_adults)
+    children = np.asarray(num_children)
+    if np.any(adults < 0) or np.any(children < 0):
+        raise ValueError("Number of persons cannot be negative")
+    child_only = (adults == 0) & (children > 0)
+    if np.any(child_only):
+        raise ValueError(
+            "SPM units must have at least one adult. "
+            "Received num_adults=0 with num_children>0, which is not a valid "
+            "SPM unit."
+        )
+
+
 class SPMCalculator:
     """Calculator for SPM thresholds."""
 
@@ -86,8 +110,7 @@ class SPMCalculator:
                 f"Must be one of: {VALID_TENURE_TYPES}"
             )
 
-        if num_adults < 0 or num_children < 0:
-            raise ValueError("Number of persons cannot be negative")
+        _validate_household_composition(num_adults, num_children)
 
         if num_adults == 0 and num_children == 0:
             return 0.0
@@ -132,6 +155,8 @@ class SPMCalculator:
                     f"Invalid tenure type: {tenure_type}. "
                     f"Must be one of: {VALID_TENURE_TYPES}"
                 )
+
+        _validate_household_composition(num_adults, num_children)
 
         base_thresholds = self.get_base_thresholds()
         equiv_scales = spm_equivalence_scale(num_adults, num_children)

--- a/spm_calculator/equivalence_scale.py
+++ b/spm_calculator/equivalence_scale.py
@@ -49,24 +49,29 @@ def spm_equivalence_scale(
     )
 
     raw = np.zeros_like(adults, dtype=float)
-    has_people = (adults + children) > 0
-    with_children = has_people & (children > 0)
+    # A "child-only" unit (0 adults with children > 0) is not a valid SPM
+    # unit — every SPM unit is headed by at least one reference person
+    # aged 15+. Treat it like the zero-person case and leave `raw` at 0.0
+    # so the calculator surfaces the impossibility downstream rather than
+    # synthesising a single-parent scale from a ghost adult.
+    has_adults = adults > 0
+    with_children = has_adults & (children > 0)
 
-    single_adult_with_children = with_children & (adults <= 1)
+    single_adult_with_children = with_children & (adults == 1)
     raw[single_adult_with_children] = (
         1.0
         + 0.8
         + 0.5 * np.maximum(children[single_adult_with_children] - 1, 0)
     ) ** 0.7
 
-    multi_adult_with_children = with_children & ~single_adult_with_children
+    multi_adult_with_children = with_children & (adults > 1)
     raw[multi_adult_with_children] = (
         adults[multi_adult_with_children]
         + 0.5 * children[multi_adult_with_children]
     ) ** 0.7
 
-    no_children = has_people & ~with_children
-    one_adult = no_children & (adults <= 1)
+    no_children = has_adults & (children == 0)
+    one_adult = no_children & (adults == 1)
     two_adults = no_children & (adults == 2)
     larger_adult_units = no_children & (adults > 2)
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -184,6 +184,62 @@ class TestThresholdCalculation:
         assert 0.75 < ratio < 0.90
 
 
+class TestHouseholdValidation:
+    """Guards against child-only and negative-count SPM unit inputs."""
+
+    def test_zero_adults_with_children_raises_scalar(self):
+        from spm_calculator import SPMCalculator
+
+        calc = SPMCalculator(year=2024)
+        with pytest.raises(ValueError, match="at least one adult"):
+            calc.calculate_threshold(
+                num_adults=0,
+                num_children=2,
+                tenure="renter",
+                geography_type="nation",
+                geography_id="US",
+            )
+
+    def test_zero_adults_with_children_raises_batch(self):
+        from spm_calculator import SPMCalculator
+
+        calc = SPMCalculator(year=2024)
+        with pytest.raises(ValueError, match="at least one adult"):
+            calc.calculate_thresholds(
+                num_adults=np.array([1, 0, 2]),
+                num_children=np.array([0, 2, 2]),
+                tenure="renter",
+                geography_type="nation",
+                geography_ids="US",
+            )
+
+    def test_negative_counts_raise_batch(self):
+        from spm_calculator import SPMCalculator
+
+        calc = SPMCalculator(year=2024)
+        with pytest.raises(ValueError, match="cannot be negative"):
+            calc.calculate_thresholds(
+                num_adults=np.array([-1, 2]),
+                num_children=np.array([0, 2]),
+                tenure="renter",
+                geography_type="nation",
+                geography_ids="US",
+            )
+
+    def test_negative_children_raises_batch(self):
+        from spm_calculator import SPMCalculator
+
+        calc = SPMCalculator(year=2024)
+        with pytest.raises(ValueError, match="cannot be negative"):
+            calc.calculate_thresholds(
+                num_adults=np.array([2, 2]),
+                num_children=np.array([0, -1]),
+                tenure="renter",
+                geography_type="nation",
+                geography_ids="US",
+            )
+
+
 class TestBatchCalculation:
     """Test batch/vectorized threshold calculation."""
 

--- a/tests/test_equivalence_scale.py
+++ b/tests/test_equivalence_scale.py
@@ -123,8 +123,14 @@ class TestEquivalenceScaleFromPersons:
         )
         assert result == pytest.approx((1.0 + 0.8) ** 0.7)
 
-    def test_more_children_than_persons_treated_like_single_parent(self):
+    def test_more_children_than_persons_returns_zero(self):
+        """An SPM unit with more children than total persons is not a
+        valid household — it would imply zero (or negative) adults. The
+        helper clamps adults at zero and a zero-adult unit returns scale
+        0 rather than synthesising a single-parent scale from a ghost
+        adult. Users who want the old "single parent of N children"
+        reading should call ``spm_equivalence_scale(1, N)`` explicitly."""
         result = equivalence_scale_from_persons(
             num_persons=2, num_children=5, normalize=False
         )
-        assert result == pytest.approx((1.0 + 0.8 + 0.5 * 4) ** 0.7)
+        assert result == pytest.approx(0.0)

--- a/web/src/components/CalculatorWorkbench.jsx
+++ b/web/src/components/CalculatorWorkbench.jsx
@@ -83,10 +83,14 @@ function fmtPercent(value) {
 }
 
 function getRawEquivalenceScale(adults, children, methodology) {
-  if (adults === 0 && children === 0) return 0;
+  // Child-only ("0 adults, N children") units aren't valid SPM households,
+  // so we return 0 rather than synthesising a single-parent scale from a
+  // ghost adult. This matches the Python helper in
+  // `spm_calculator.equivalence_scale.spm_equivalence_scale`.
+  if (adults === 0) return 0;
 
   if (children > 0) {
-    if (adults <= 1) {
+    if (adults === 1) {
       return (
         1 +
         methodology.equivalenceScale.singleAdultFirstChild +
@@ -99,20 +103,20 @@ function getRawEquivalenceScale(adults, children, methodology) {
     ) ** methodology.equivalenceScale.economiesOfScale;
   }
 
-  if (adults <= 1) return 1;
+  if (adults === 1) return 1;
   if (adults === 2) return methodology.equivalenceScale.twoAdultNoChild;
   return adults ** methodology.equivalenceScale.economiesOfScale;
 }
 
 function describeEquivalenceFormula(adults, children) {
-  if (adults === 0 && children === 0) return "0";
+  if (adults === 0) return "0";
   if (children > 0) {
-    if (adults <= 1) {
+    if (adults === 1) {
       return `(1 + 0.8 + 0.5 * (${children} - 1))^0.7`;
     }
     return `(${adults} + 0.5 * ${children})^0.7`;
   }
-  if (adults <= 1) return "1.0";
+  if (adults === 1) return "1.0";
   if (adults === 2) return "1.41";
   return `${adults}^0.7`;
 }


### PR DESCRIPTION
## Summary

Three related inputs that shouldn't produce a positive threshold but did:

1. **Scalar child-only unit.** `calculate_threshold(0, 2, ...)` returned ~$32k because the zero-adult guard only fired for `(0, 0)` and the equivalence-scale single-parent branch matched `adults <= 1`, so a ghost-adult household was priced like a single-parent-of-two.
2. **Batch path skipped negative-count validation.** `calculate_thresholds` silently produced `0.0` for `(0, 2)` rows and returned `[0.0, 39430.0]` for `num_adults=[-1, 2]` — no error, no warning.
3. **Web mirrored (1).** Entering 0 adults + any children in the UI showed a positive threshold.

## Changes

- `spm_calculator/calculator.py` — extract `_validate_household_composition` and call it from both the scalar and batch paths. Rejects negative counts and `(0 adults, children > 0)` with actionable messages.
- `spm_calculator/equivalence_scale.py` — tighten `spm_equivalence_scale` so zero-adult rows return 0 rather than matching the single-parent branch. The old `adults <= 1` guards are now `adults == 1`; a zero-adult row falls through to the `raw` zero-init.
- `tests/test_equivalence_scale.py` — update the single test that encoded the old bug (more children than persons → single parent of N kids). The helper now clamps adults at 0 and returns a zero scale.
- `web/src/components/CalculatorWorkbench.jsx` — mirror the Python change in `getRawEquivalenceScale` / `describeEquivalenceFormula` so the web shows 0 for child-only inputs instead of computing a single-parent-of-N figure.

## Test plan

- [x] `uv run pytest -x -q` → 91 passed, 16 skipped (was 87 / 16)
- [x] `bunx next build` → static export succeeds
- [x] New regression tests in `TestHouseholdValidation`:
  - `test_zero_adults_with_children_raises_scalar`
  - `test_zero_adults_with_children_raises_batch`
  - `test_negative_counts_raise_batch`
  - `test_negative_children_raises_batch`

Fixes findings 2 and 3 from the bug hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
