### PR TITLE
CE-threshold correctness fixes (schema detection, has-child filter, empty percentile, published years)

### DIFF
--- a/spm_calculator/ce_threshold.py
+++ b/spm_calculator/ce_threshold.py
@@ -206,9 +206,10 @@ def get_tenure_type(df: pd.DataFrame) -> pd.Series:
     if "ce_year" in df.columns and len(df) > 0:
         ce_year = df["ce_year"]
         is_modern_schema = (ce_year.astype(int) >= MODERN_CUTENURE_YEAR).all()
-        if not is_modern_schema and not (
-            ce_year.astype(int) < MODERN_CUTENURE_YEAR
-        ).all():
+        if (
+            not is_modern_schema
+            and not (ce_year.astype(int) < MODERN_CUTENURE_YEAR).all()
+        ):
             raise ValueError(
                 "Dataset mixes pre-2013 and post-2013 CE vintages "
                 "(CUTENURE schema changed in 2013). Split by `ce_year` "

--- a/spm_calculator/ce_threshold.py
+++ b/spm_calculator/ce_threshold.py
@@ -33,12 +33,20 @@ from .fcsuti_cpi import get_fcsuti_inflation_factor
 # BLS CE Survey PUMD base URL
 CE_PUMD_BASE_URL = "https://www.bls.gov/cex/pumd/data/comma"
 
-# Published BLS thresholds for validation (2024)
-BLS_PUBLISHED_THRESHOLDS_2024 = {
-    "renter": 39430,
-    "owner_with_mortgage": 39068,
-    "owner_without_mortgage": 32586,
-}
+
+def _get_bls_published_thresholds_2024() -> dict[str, float]:
+    """Return the 2024 published BLS thresholds from the single source
+    of truth (``forecast.HISTORICAL_THRESHOLDS``)."""
+    from .forecast import HISTORICAL_THRESHOLDS
+
+    return HISTORICAL_THRESHOLDS[2024].copy()
+
+
+# Kept for backwards compatibility with callers that imported the
+# module-level constant. The canonical source is
+# ``spm_calculator.forecast.HISTORICAL_THRESHOLDS[2024]``; mirroring
+# it as a dict here avoids the drift risk of two copies.
+BLS_PUBLISHED_THRESHOLDS_2024 = _get_bls_published_thresholds_2024()
 
 
 def download_ce_fmli(year: int, quarter: int) -> pd.DataFrame:
@@ -159,11 +167,14 @@ def calculate_fcsuti(df: pd.DataFrame) -> pd.Series:
     return (food + apparel + shelter + utilities + telephone + info_tech) * 2
 
 
+MODERN_CUTENURE_YEAR = 2013
+
+
 def get_tenure_type(df: pd.DataFrame) -> pd.Series:
     """Determine housing tenure type (renter, owner_with_mortgage,
     owner_without_mortgage) from CE FMLI data.
 
-    CUTENURE codes:
+    CUTENURE codes (post-2013):
         1 = Owned with mortgage
         2 = Owned without mortgage
         3 = Rented
@@ -171,12 +182,20 @@ def get_tenure_type(df: pd.DataFrame) -> pd.Series:
         5 = Student housing
 
     BLS expanded the CUTENURE codes in 2013 to split owners by mortgage
-    status, so CUTENURE alone is authoritative in modern vintages. For
-    older vintages (where CUTENURE == 1 meant any owner), we fall back
-    to presence of mortgage interest/principal expenditure.
+    status. Schema is detected from ``ce_year`` — previously we looked
+    at observed codes (``(cutenure >= 3).any()``), which silently fell
+    into the legacy branch whenever a caller happened to filter to an
+    owners-only subset and re-labelled `CUTENURE == 2` rows as renters
+    even though the modern schema calls them owners-without-mortgage.
+
+    For legacy (pre-2013) vintages, owner-vs-owner-with-mortgage is
+    derived from mortgage interest/principal expenditure.
 
     Args:
-        df: CE Survey FMLI DataFrame
+        df: CE Survey FMLI DataFrame. Must contain ``CUTENURE``; for
+            ambiguous vintages (pre-2013) it must also contain
+            ``ce_year`` so the schema can be resolved at load time
+            rather than from observed codes.
 
     Returns:
         Series of tenure strings aligned with ``df.index``.
@@ -184,10 +203,35 @@ def get_tenure_type(df: pd.DataFrame) -> pd.Series:
     tenure = pd.Series("renter", index=df.index, dtype=object)
     cutenure = df["CUTENURE"]
 
-    # Modern CUTENURE codes span {1, 2, 3, 4, 5}; the legacy pre-2013
-    # codes only used {1, 2}. If any row uses a code >= 3, the dataset
-    # is on the modern schema.
-    is_modern_schema = (cutenure >= 3).any()
+    if "ce_year" in df.columns and len(df) > 0:
+        ce_year = df["ce_year"]
+        is_modern_schema = (ce_year.astype(int) >= MODERN_CUTENURE_YEAR).all()
+        if not is_modern_schema and not (
+            ce_year.astype(int) < MODERN_CUTENURE_YEAR
+        ).all():
+            raise ValueError(
+                "Dataset mixes pre-2013 and post-2013 CE vintages "
+                "(CUTENURE schema changed in 2013). Split by `ce_year` "
+                "before calling `get_tenure_type`."
+            )
+    elif len(df) == 0:
+        # Empty frame: schema is irrelevant, return the empty series.
+        return tenure
+    else:
+        # No `ce_year` column: fall back to the legacy observed-code
+        # heuristic with an explicit warning, since that's the only
+        # signal left. This path is only for ad-hoc callers passing
+        # bare CE frames; the PUMD download path always annotates
+        # `ce_year`.
+        warnings.warn(
+            "get_tenure_type called without `ce_year` column; falling "
+            "back to observed-code schema detection, which misclassifies "
+            "owners-only subsets on the modern schema. Pass a `ce_year` "
+            "column to disambiguate.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        is_modern_schema = (cutenure >= 3).any()
 
     if is_modern_schema:
         # 1 = owner w/ mortgage, 2 = owner w/o, 3 = renter.
@@ -229,10 +273,19 @@ def _weighted_percentile(
     statistics packages (e.g., R's ``Hmisc::wtd.quantile`` with
     ``type='i/n'``) and is the sensible extension of BLS's
     percentile-range threshold approach to weighted CU data.
+
+    Empty input returns NaN rather than indexing into `cumulative[-1]`
+    on a zero-length array; this path is reachable when a tenure bucket
+    drops to zero rows after `dropna` *and* the pooled fallback also
+    drops to empty.
     """
+    values = np.asarray(values)
+    weights = np.asarray(weights, dtype=float)
+    if values.size == 0 or weights.size == 0:
+        return float("nan")
     order = np.argsort(values)
-    values = np.asarray(values)[order]
-    weights = np.asarray(weights, dtype=float)[order]
+    values = values[order]
+    weights = weights[order]
     cumulative = np.cumsum(weights)
     total = cumulative[-1]
     if total <= 0:
@@ -292,10 +345,21 @@ def calculate_base_thresholds(
     try:
         ce = download_ce_pumd_years(years)
 
-        if "PERSLT18" in ce.columns:
-            ce = ce[ce["PERSLT18"] > 0].copy()
-        elif "FAM_SIZE" in ce.columns and "PERSOT64" in ce.columns:
-            ce = ce[ce["FAM_SIZE"] > ce.get("PERSOT64", 0)].copy()
+        # The BLS methodology requires consumer units with at least one
+        # child under 18. FMLI publishes `PERSLT18` for every vintage we
+        # care about (2013+); if it's missing we refuse rather than
+        # using the old `FAM_SIZE > PERSOT64` heuristic, which silently
+        # matches any non-elderly CU — including two-adult / zero-child
+        # units — and therefore miscalibrates the threshold.
+        if "PERSLT18" not in ce.columns:
+            raise ValueError(
+                "CE data is missing the 'PERSLT18' column required to "
+                "restrict to consumer units with children. The previous "
+                "fallback (FAM_SIZE > PERSOT64) is a methodology error "
+                "because it matches any CU with at least one non-elderly "
+                "member, not a CU with a child under 18."
+            )
+        ce = ce[ce["PERSLT18"] > 0].copy()
 
         if len(ce) == 0:
             raise ValueError("No consumer units with children found")
@@ -376,6 +440,12 @@ def get_published_thresholds(year: int) -> dict[str, float]:
     """
     Get published BLS SPM thresholds for a given year.
 
+    Sources from ``forecast.HISTORICAL_THRESHOLDS`` so the available
+    range stays in lockstep with the forecast path. Previously this
+    function hard-coded 2022–2024 while the forecast module had 2015–2024,
+    so `get_published_thresholds(2020)` raised even though the published
+    value existed.
+
     Args:
         year: Calendar year
 
@@ -385,28 +455,14 @@ def get_published_thresholds(year: int) -> dict[str, float]:
     Raises:
         ValueError: If published thresholds not available for the year
     """
-    published = {
-        2024: {
-            "renter": 39430,
-            "owner_with_mortgage": 39068,
-            "owner_without_mortgage": 32586,
-        },
-        2023: {
-            "renter": 36606,
-            "owner_with_mortgage": 36192,
-            "owner_without_mortgage": 30347,
-        },
-        2022: {
-            "renter": 33402,
-            "owner_with_mortgage": 32949,
-            "owner_without_mortgage": 27679,
-        },
-    }
+    # Lazy import avoids a circular import at module load.
+    from .forecast import HISTORICAL_THRESHOLDS
 
-    if year in published:
-        return published[year].copy()
-    else:
-        raise ValueError(
-            f"Published thresholds not available for {year}. "
-            f"Available years: {list(published.keys())}"
-        )
+    if year in HISTORICAL_THRESHOLDS:
+        return HISTORICAL_THRESHOLDS[year].copy()
+
+    available = sorted(HISTORICAL_THRESHOLDS.keys())
+    raise ValueError(
+        f"Published thresholds not available for {year}. "
+        f"Available years: {available}"
+    )

--- a/tests/test_base_thresholds.py
+++ b/tests/test_base_thresholds.py
@@ -44,10 +44,22 @@ class TestPublishedThresholds:
         assert thresholds["owner_with_mortgage"] == 32949
         assert thresholds["owner_without_mortgage"] == 27679
 
+    def test_published_thresholds_cover_full_historical_range(self):
+        """`get_published_thresholds` must expose the same years as
+        `forecast.HISTORICAL_THRESHOLDS` (2015–2024), not just 2022–2024
+        as an older hardcoded dict used to."""
+        from spm_calculator.forecast import HISTORICAL_THRESHOLDS
+
+        for year in HISTORICAL_THRESHOLDS:
+            assert (
+                get_published_thresholds(year)
+                == HISTORICAL_THRESHOLDS[year]
+            ), f"get_published_thresholds({year}) drifted from HISTORICAL_THRESHOLDS"
+
     def test_unavailable_year_raises(self):
-        """Requesting unavailable year should raise ValueError."""
+        """Pre-2015 and far-future years are genuinely unavailable."""
         with pytest.raises(ValueError, match="not available"):
-            get_published_thresholds(2015)
+            get_published_thresholds(2010)
 
     def test_returns_copy(self):
         """Should return a copy, not the original dict."""
@@ -157,6 +169,39 @@ class TestCEThresholdMethodology:
         )
 
         assert thresholds["renter"] == pytest.approx(124.5)
+
+    def test_calculate_base_thresholds_requires_perslt18(self, monkeypatch):
+        """Regression: without `PERSLT18`, the old fallback
+        `FAM_SIZE > PERSOT64` silently matched any CU with a non-elderly
+        member, including two-adult / zero-child units — a methodology
+        error. The function now refuses rather than producing a wrong
+        number."""
+        import pandas as pd
+
+        import spm_calculator.ce_threshold as ce_threshold
+
+        # A two-adult no-child CU would pass the old fallback
+        # (FAM_SIZE=2 > PERSOT64=0) but must not be included.
+        sample = pd.DataFrame(
+            {
+                "CUTENURE": [2, 2],
+                "FAM_SIZE": [2, 2],
+                "PERSOT64": [0, 0],
+                "ADULT": [2, 2],
+                "ce_year": [2022, 2023],
+            }
+        )
+
+        monkeypatch.setattr(
+            ce_threshold, "download_ce_pumd_years", lambda years: sample.copy()
+        )
+
+        with pytest.raises(ValueError, match="PERSLT18"):
+            ce_threshold.calculate_base_thresholds(
+                years=[2022, 2023],
+                target_year=2024,
+                use_published_fallback=False,
+            )
 
 
 # TODO: Add integration tests that actually download CE data

--- a/tests/test_base_thresholds.py
+++ b/tests/test_base_thresholds.py
@@ -52,8 +52,7 @@ class TestPublishedThresholds:
 
         for year in HISTORICAL_THRESHOLDS:
             assert (
-                get_published_thresholds(year)
-                == HISTORICAL_THRESHOLDS[year]
+                get_published_thresholds(year) == HISTORICAL_THRESHOLDS[year]
             ), f"get_published_thresholds({year}) drifted from HISTORICAL_THRESHOLDS"
 
     def test_unavailable_year_raises(self):

--- a/tests/test_ce_helpers.py
+++ b/tests/test_ce_helpers.py
@@ -101,7 +101,12 @@ class TestCalculateFCSUti:
 class TestGetTenureType:
     def test_modern_cutenure_codes_split_owners(self):
         """Post-2013 FMLI: 1=owner w/mortgage, 2=owner w/o, 3=renter."""
-        df = pd.DataFrame({"CUTENURE": [1, 2, 3, 4]})
+        df = pd.DataFrame(
+            {
+                "CUTENURE": [1, 2, 3, 4],
+                "ce_year": [2020, 2020, 2020, 2020],
+            }
+        )
         tenure = get_tenure_type(df)
         assert tenure.tolist() == [
             "owner_with_mortgage",
@@ -117,6 +122,7 @@ class TestGetTenureType:
                 # No row uses the modern code 2 for owner-without; the
                 # branch falls back to mortgage-expenditure detection.
                 "CUTENURE": [1, 1, 2],
+                "ce_year": [2010, 2010, 2010],
                 "MRTPRINPQ": [500, 0, 0],
                 "MRTPRINCQ": [500, 0, 0],
                 "MRTINTPQ": [0, 0, 0],
@@ -129,6 +135,42 @@ class TestGetTenureType:
             "owner_without_mortgage",
             "renter",
         ]
+
+    def test_owners_only_modern_subset_labels_by_schema_not_observed_codes(
+        self,
+    ):
+        """Regression: filtering a modern CE vintage down to owners-only
+        (CUTENURE ∈ {1, 2}) used to trip the observed-code heuristic
+        (`(cutenure >= 3).any() == False`) and misclassify rows as
+        legacy-schema, relabelling `CUTENURE == 2` as renter. With
+        schema derived from `ce_year`, owners-only subsets on the modern
+        schema classify correctly."""
+        df = pd.DataFrame(
+            {
+                "CUTENURE": [1, 2, 1, 2],
+                "ce_year": [2020, 2020, 2020, 2020],
+            }
+        )
+        tenure = get_tenure_type(df)
+        assert tenure.tolist() == [
+            "owner_with_mortgage",
+            "owner_without_mortgage",
+            "owner_with_mortgage",
+            "owner_without_mortgage",
+        ]
+
+    def test_mixed_vintage_raises_on_schema_ambiguity(self):
+        """Mixing pre-2013 and post-2013 rows in a single frame would
+        apply the wrong CUTENURE interpretation to at least one side;
+        we refuse rather than silently coerce."""
+        df = pd.DataFrame(
+            {
+                "CUTENURE": [1, 2],
+                "ce_year": [2010, 2020],
+            }
+        )
+        with pytest.raises(ValueError, match="mixes pre-2013 and post-2013"):
+            get_tenure_type(df)
 
 
 class TestWeightedPercentile:
@@ -175,6 +217,19 @@ class TestWeightedPercentile:
             _weighted_percentile(
                 np.array([1.0, 2.0, 3.0]),
                 np.array([0.0, 0.0, 0.0]),
+                50.0,
+            )
+        )
+
+    def test_returns_nan_on_empty_input(self):
+        """Previously the function indexed `cumulative[-1]` on an empty
+        array and raised `IndexError`. This path is reachable when a
+        tenure bucket drops to zero rows after `dropna` and the pooled
+        fallback is also empty."""
+        assert np.isnan(
+            _weighted_percentile(
+                np.array([]),
+                np.array([]),
                 50.0,
             )
         )


### PR DESCRIPTION
## Summary

Four CE-survey-path bugs, all reachable with normal usage:

1. **Legacy-schema fallback misclassified owners-only subsets.** `get_tenure_type` decided modern-vs-legacy CUTENURE schema from observed codes (`(cutenure >= 3).any()`). Any modern-vintage subset filtered to owners-only took the legacy branch and re-labelled `CUTENURE == 2` rows as renters even though the modern schema calls them owners-without-mortgage.

2. **"Has-child" fallback was wrong.** `calculate_base_thresholds` fell back to `FAM_SIZE > PERSOT64` when `PERSLT18` was missing — that condition matches any CU with at least one non-elderly member (including two-adult / zero-child units), not a CU with a child under 18.

3. **`_weighted_percentile` crashed on empty input.** `cumulative[-1]` raised `IndexError` on a zero-length array. Reachable when a tenure bucket drops to zero rows after `dropna` *and* the pooled fallback is also empty.

4. **`get_published_thresholds(2020)` raised despite data existing.** The function hard-coded 2022–2024 while `forecast.HISTORICAL_THRESHOLDS` covers 2015–2024. Two sources of truth, one stale.

## Changes

- `spm_calculator/ce_threshold.py::get_tenure_type` — derive schema from `ce_year` (added by `download_ce_fmli`), raise on mixed pre/post-2013 frames, keep the observed-code heuristic as an explicit `RuntimeWarning` path for bare callers without `ce_year`.
- `spm_calculator/ce_threshold.py::calculate_base_thresholds` — require `PERSLT18` and raise with an explanation; remove the `FAM_SIZE > PERSOT64` fallback.
- `spm_calculator/ce_threshold.py::_weighted_percentile` — early return NaN for empty input; matches the existing zero-weight branch.
- `spm_calculator/ce_threshold.py::get_published_thresholds` — read from `forecast.HISTORICAL_THRESHOLDS` (single source of truth). The module-level `BLS_PUBLISHED_THRESHOLDS_2024` constant becomes a mirror of that source so the two can't drift.

## Test plan

- [x] `uv run pytest -x -q` → 92 passed, 16 skipped (was 87 / 16)
- [x] New regression tests:
  - `test_owners_only_modern_subset_labels_by_schema_not_observed_codes`
  - `test_mixed_vintage_raises_on_schema_ambiguity`
  - `test_returns_nan_on_empty_input`
  - `test_published_thresholds_cover_full_historical_range`
  - `test_calculate_base_thresholds_requires_perslt18`

Fixes findings 4, 5, 6, and 7 from the bug hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
