### PR TITLE
Wire up PRECOMPUTED_FCSUTI_FACTORS, add BLS registration-key plumbing

### DIFF
--- a/spm_calculator/fcsuti_cpi.py
+++ b/spm_calculator/fcsuti_cpi.py
@@ -24,6 +24,7 @@ References
 - BLS SPM Thresholds: https://www.bls.gov/pir/spm/spm_thresholds_2024.htm
 """
 
+import os
 import warnings
 from functools import lru_cache
 from typing import Mapping, Optional
@@ -78,6 +79,7 @@ def fetch_bls_cpi_series(
     series_id: str,
     start_year: int = 2010,
     end_year: int = 2024,
+    registration_key: Optional[str] = None,
 ) -> pd.Series:
     """Fetch an annual-average CPI series from the BLS public API.
 
@@ -85,12 +87,20 @@ def fetch_bls_cpi_series(
         series_id: BLS series ID (e.g. ``"CUUR0000SA0"``).
         start_year: Inclusive start year.
         end_year: Inclusive end year.
+        registration_key: Optional BLS v2 registration key. Defaults to
+            ``$BLS_API_KEY`` if set. Without a key, BLS rate-limits
+            unauthenticated requests to 25 queries per IP per day —
+            enough to break `get_fcsuti_cpi` (six component series) after
+            four calls.
 
     Returns:
         Series of annual-average CPI values indexed by calendar year.
     """
     import requests
 
+    # BLS Public Data API v2. Registered access is documented at
+    # https://www.bls.gov/developers/; registered callers get 500
+    # queries/day per key with ten-year history and annual averages.
     url = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
     payload = {
         "seriesid": [series_id],
@@ -98,6 +108,10 @@ def fetch_bls_cpi_series(
         "endyear": str(end_year),
         "annualaverage": True,
     }
+    key = registration_key or os.environ.get("BLS_API_KEY")
+    if key:
+        payload["registrationkey"] = key
+
     response = requests.post(url, json=payload, timeout=30)
     response.raise_for_status()
     data = response.json()
@@ -330,6 +344,18 @@ def get_fcsuti_inflation_factor(
 ) -> float:
     """Inflation factor between two years via the FCSUti composite.
 
+    Resolution order when the BLS API is unreachable:
+
+    1. Consult `PRECOMPUTED_FCSUTI_FACTORS` for an exact year pair.
+       These are baked from published BLS FCSUti indices and are
+       materially better than the 4% constant-growth estimate when
+       they match.
+    2. Compose two precomputed factors through a common target year
+       (e.g. `(2019, 2024)` × `(2024, 2026)` when only direct pairs
+       to 2024 are baked). This extends the precomputed coverage
+       across the full range without shipping a quadratic table.
+    3. Fall back to 4% annual growth.
+
     Args:
         from_year: Starting year (sets the index base).
         to_year: Target year.
@@ -341,6 +367,9 @@ def get_fcsuti_inflation_factor(
         dollars. Falls back to a ~4%/yr estimate if the BLS series
         fetch fails, and emits a :class:`RuntimeWarning` in that case.
     """
+    if from_year == to_year:
+        return 1.0
+
     if weights is None:
         warnings.warn(
             _STATIC_WEIGHTS_WARNING,
@@ -348,6 +377,7 @@ def get_fcsuti_inflation_factor(
             stacklevel=2,
         )
         weights = FCSUTI_WEIGHTS
+
     try:
         fcsuti = get_fcsuti_cpi(
             start_year=min(from_year, to_year) - 1,
@@ -357,12 +387,70 @@ def get_fcsuti_inflation_factor(
         )
         return fcsuti[to_year] / 100.0
     except Exception as e:
+        direct = get_precomputed_fcsuti_factor(from_year, to_year)
+        if direct is not None:
+            warnings.warn(
+                f"Could not fetch FCSUti CPI ({e}); using precomputed "
+                f"factor for ({from_year}, {to_year}).",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return direct
+
+        composed = _compose_precomputed_fcsuti_factor(from_year, to_year)
+        if composed is not None:
+            warnings.warn(
+                f"Could not fetch FCSUti CPI ({e}); using composed "
+                f"precomputed factors for ({from_year}, {to_year}).",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return composed
+
         warnings.warn(
-            f"Could not get FCSUti CPI ({e}); falling back to 4%/yr estimate.",
+            f"Could not fetch FCSUti CPI ({e}); no precomputed factor "
+            f"matches ({from_year}, {to_year}), falling back to 4%/yr estimate.",
             RuntimeWarning,
             stacklevel=2,
         )
         return 1.04 ** (to_year - from_year)
+
+
+def _compose_precomputed_fcsuti_factor(
+    from_year: int,
+    to_year: int,
+) -> Optional[float]:
+    """Chain two precomputed factors through a common pivot year.
+
+    Returns ``factor[(from_year, pivot)] * factor[(pivot, to_year)]`` if
+    a single pivot year closes the gap. Inverts stored factors as needed
+    so we don't need to double the table size to cover both directions.
+    """
+    pivots = {pair[1] for pair in PRECOMPUTED_FCSUTI_FACTORS} | {
+        pair[0] for pair in PRECOMPUTED_FCSUTI_FACTORS
+    }
+    for pivot in pivots:
+        first = _directed_precomputed_factor(from_year, pivot)
+        second = _directed_precomputed_factor(pivot, to_year)
+        if first is not None and second is not None:
+            return first * second
+    return None
+
+
+def _directed_precomputed_factor(
+    from_year: int, to_year: int
+) -> Optional[float]:
+    """Precomputed factor in either direction (invert if stored the
+    other way). Returns None if neither direction is stored."""
+    if from_year == to_year:
+        return 1.0
+    direct = PRECOMPUTED_FCSUTI_FACTORS.get((from_year, to_year))
+    if direct is not None:
+        return direct
+    reverse = PRECOMPUTED_FCSUTI_FACTORS.get((to_year, from_year))
+    if reverse is not None and reverse != 0:
+        return 1.0 / reverse
+    return None
 
 
 # Pre-computed FCSUti inflation factors for common year pairs. Retained

--- a/tests/test_fcsuti_cpi.py
+++ b/tests/test_fcsuti_cpi.py
@@ -250,9 +250,10 @@ class TestStaticWeightsShape:
 
 class TestPrecomputedFactor:
     def test_returns_direct_pair(self):
-        assert get_precomputed_fcsuti_factor(
-            2023, 2024
-        ) == PRECOMPUTED_FCSUTI_FACTORS[(2023, 2024)]
+        assert (
+            get_precomputed_fcsuti_factor(2023, 2024)
+            == PRECOMPUTED_FCSUTI_FACTORS[(2023, 2024)]
+        )
 
     def test_returns_none_when_missing(self):
         assert get_precomputed_fcsuti_factor(2001, 2099) is None
@@ -276,9 +277,9 @@ class TestComposedFactor:
         direct_19_24 = PRECOMPUTED_FCSUTI_FACTORS[(2019, 2024)]
         direct_22_24 = PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)]
         expected = direct_19_24 * (1.0 / direct_22_24)
-        assert _compose_precomputed_fcsuti_factor(
-            2019, 2022
-        ) == pytest.approx(expected)
+        assert _compose_precomputed_fcsuti_factor(2019, 2022) == pytest.approx(
+            expected
+        )
 
     def test_returns_none_when_no_pivot_works(self):
         assert _compose_precomputed_fcsuti_factor(1985, 1990) is None
@@ -315,9 +316,9 @@ class TestInflationFactorOfflineFallback:
         monkeypatch.setattr(mod, "fetch_bls_cpi_series", fail_fetch)
 
         factor = get_fcsuti_inflation_factor(2019, 2022)
-        composed = PRECOMPUTED_FCSUTI_FACTORS[
-            (2019, 2024)
-        ] * (1.0 / PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)])
+        composed = PRECOMPUTED_FCSUTI_FACTORS[(2019, 2024)] * (
+            1.0 / PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)]
+        )
         assert factor == pytest.approx(composed)
 
     def test_falls_back_to_4pct_when_nothing_precomputed_matches(

--- a/tests/test_fcsuti_cpi.py
+++ b/tests/test_fcsuti_cpi.py
@@ -291,7 +291,7 @@ class TestInflationFactorOfflineFallback:
         consult `PRECOMPUTED_FCSUTI_FACTORS` before the 4%/yr estimate."""
         import spm_calculator.fcsuti_cpi as mod
 
-        mod.get_fcsuti_cpi.cache_clear()
+        mod._cached_fcsuti_cpi.cache_clear()
 
         def fail_fetch(*args, **kwargs):
             raise RuntimeError("no network")
@@ -308,7 +308,7 @@ class TestInflationFactorOfflineFallback:
         used before the 4%/yr estimate."""
         import spm_calculator.fcsuti_cpi as mod
 
-        mod.get_fcsuti_cpi.cache_clear()
+        mod._cached_fcsuti_cpi.cache_clear()
 
         def fail_fetch(*args, **kwargs):
             raise RuntimeError("no network")
@@ -330,7 +330,7 @@ class TestInflationFactorOfflineFallback:
 
         import spm_calculator.fcsuti_cpi as mod
 
-        mod.get_fcsuti_cpi.cache_clear()
+        mod._cached_fcsuti_cpi.cache_clear()
         monkeypatch.setattr(
             mod,
             "fetch_bls_cpi_series",

--- a/tests/test_fcsuti_cpi.py
+++ b/tests/test_fcsuti_cpi.py
@@ -2,9 +2,13 @@
 
 Covers the pure-function helpers that run without hitting the BLS API:
 ``compute_fcsuti_weights_from_ce`` and the ``weights`` plumbing on the
-composite-CPI builders. End-to-end tests that actually fetch BLS data
-are network-gated in ``test_ce_validation.py``.
+composite-CPI builders, plus the offline fallback paths (precomputed
+factors, composed factors) and the BLS registration-key plumbing.
+End-to-end tests that actually fetch BLS data are network-gated in
+``test_ce_validation.py``.
 """
+
+from __future__ import annotations
 
 import warnings
 
@@ -14,9 +18,14 @@ import pytest
 from spm_calculator import fcsuti_cpi
 from spm_calculator.fcsuti_cpi import (
     FCSUTI_WEIGHTS,
+    PRECOMPUTED_FCSUTI_FACTORS,
+    _compose_precomputed_fcsuti_factor,
+    _directed_precomputed_factor,
     compute_fcsuti_weights_from_ce,
+    fetch_bls_cpi_series,
     get_fcsuti_cpi,
     get_fcsuti_inflation_factor,
+    get_precomputed_fcsuti_factor,
 )
 
 
@@ -237,3 +246,219 @@ class TestStaticWeightsShape:
         """The fallback dict is a rough approximation but the shares
         should still integrate to 1.0 to within normal rounding."""
         assert sum(FCSUTI_WEIGHTS.values()) == pytest.approx(1.0, abs=0.01)
+
+
+class TestPrecomputedFactor:
+    def test_returns_direct_pair(self):
+        assert get_precomputed_fcsuti_factor(
+            2023, 2024
+        ) == PRECOMPUTED_FCSUTI_FACTORS[(2023, 2024)]
+
+    def test_returns_none_when_missing(self):
+        assert get_precomputed_fcsuti_factor(2001, 2099) is None
+
+
+class TestDirectedPrecomputedFactor:
+    def test_inverts_stored_reverse_pair(self):
+        forward = PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)]
+        assert _directed_precomputed_factor(2024, 2022) == pytest.approx(
+            1.0 / forward
+        )
+
+    def test_same_year_returns_one(self):
+        assert _directed_precomputed_factor(2020, 2020) == 1.0
+
+
+class TestComposedFactor:
+    def test_chains_through_pivot(self):
+        """(2019, 2022) is not directly baked, but (2019, 2024) and
+        (2022, 2024) are; composing inverts the second and multiplies."""
+        direct_19_24 = PRECOMPUTED_FCSUTI_FACTORS[(2019, 2024)]
+        direct_22_24 = PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)]
+        expected = direct_19_24 * (1.0 / direct_22_24)
+        assert _compose_precomputed_fcsuti_factor(
+            2019, 2022
+        ) == pytest.approx(expected)
+
+    def test_returns_none_when_no_pivot_works(self):
+        assert _compose_precomputed_fcsuti_factor(1985, 1990) is None
+
+
+class TestInflationFactorOfflineFallback:
+    def test_uses_precomputed_when_api_fails(self, monkeypatch):
+        """With the BLS fetch stubbed to raise, the resolver should
+        consult `PRECOMPUTED_FCSUTI_FACTORS` before the 4%/yr estimate."""
+        import spm_calculator.fcsuti_cpi as mod
+
+        mod.get_fcsuti_cpi.cache_clear()
+
+        def fail_fetch(*args, **kwargs):
+            raise RuntimeError("no network")
+
+        monkeypatch.setattr(mod, "fetch_bls_cpi_series", fail_fetch)
+
+        factor = get_fcsuti_inflation_factor(2023, 2024)
+        assert factor == pytest.approx(
+            PRECOMPUTED_FCSUTI_FACTORS[(2023, 2024)]
+        )
+
+    def test_uses_composition_when_direct_not_available(self, monkeypatch):
+        """Without an exact direct pair, composition through 2024 is
+        used before the 4%/yr estimate."""
+        import spm_calculator.fcsuti_cpi as mod
+
+        mod.get_fcsuti_cpi.cache_clear()
+
+        def fail_fetch(*args, **kwargs):
+            raise RuntimeError("no network")
+
+        monkeypatch.setattr(mod, "fetch_bls_cpi_series", fail_fetch)
+
+        factor = get_fcsuti_inflation_factor(2019, 2022)
+        composed = PRECOMPUTED_FCSUTI_FACTORS[
+            (2019, 2024)
+        ] * (1.0 / PRECOMPUTED_FCSUTI_FACTORS[(2022, 2024)])
+        assert factor == pytest.approx(composed)
+
+    def test_falls_back_to_4pct_when_nothing_precomputed_matches(
+        self, monkeypatch
+    ):
+        """For year pairs outside the precomputed universe, the 4%/yr
+        estimate is the last resort (and emits a RuntimeWarning)."""
+        import warnings
+
+        import spm_calculator.fcsuti_cpi as mod
+
+        mod.get_fcsuti_cpi.cache_clear()
+        monkeypatch.setattr(
+            mod,
+            "fetch_bls_cpi_series",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("x")),
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            factor = get_fcsuti_inflation_factor(1985, 1990)
+        assert factor == pytest.approx(1.04**5)
+        assert any("4%/yr" in str(w.message) for w in caught)
+
+    def test_same_year_returns_identity(self):
+        assert get_fcsuti_inflation_factor(2024, 2024) == 1.0
+
+
+class TestRegistrationKey:
+    def test_fetch_passes_registration_key_when_provided(self, monkeypatch):
+        """When a registrationkey is supplied, it must be part of the
+        POST payload. Without one, callers are capped at 25 BLS queries
+        per IP per day (which is four `get_fcsuti_cpi` calls)."""
+        import requests
+
+        captured = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "status": "REQUEST_SUCCEEDED",
+                    "Results": {
+                        "series": [
+                            {
+                                "data": [
+                                    {
+                                        "year": "2024",
+                                        "period": "M13",
+                                        "value": "100.0",
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                }
+
+        def fake_post(url, json=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse()
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        fetch_bls_cpi_series(
+            "CUUR0000SAF", 2023, 2024, registration_key="abc123"
+        )
+        assert captured["json"]["registrationkey"] == "abc123"
+
+    def test_fetch_reads_registration_key_from_env(self, monkeypatch):
+        """If no explicit key is passed, BLS_API_KEY is picked up from
+        the environment so CI runners can register silently."""
+        import requests
+
+        captured = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "status": "REQUEST_SUCCEEDED",
+                    "Results": {
+                        "series": [
+                            {
+                                "data": [
+                                    {
+                                        "year": "2024",
+                                        "period": "M13",
+                                        "value": "100.0",
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                }
+
+        def fake_post(url, json=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse()
+
+        monkeypatch.setenv("BLS_API_KEY", "env-key")
+        monkeypatch.setattr(requests, "post", fake_post)
+        fetch_bls_cpi_series("CUUR0000SAF", 2023, 2024)
+        assert captured["json"]["registrationkey"] == "env-key"
+
+    def test_fetch_omits_registration_key_when_absent(self, monkeypatch):
+        """No key, no `registrationkey` field (so we don't send an
+        empty string that some clients might reject)."""
+        import requests
+
+        captured = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "status": "REQUEST_SUCCEEDED",
+                    "Results": {
+                        "series": [
+                            {
+                                "data": [
+                                    {
+                                        "year": "2024",
+                                        "period": "M13",
+                                        "value": "100.0",
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                }
+
+        def fake_post(url, json=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse()
+
+        monkeypatch.delenv("BLS_API_KEY", raising=False)
+        monkeypatch.setattr(requests, "post", fake_post)
+        fetch_bls_cpi_series("CUUR0000SAF", 2023, 2024)
+        assert "registrationkey" not in captured["json"]


### PR DESCRIPTION
## Summary

Two FCSUti module bugs that compound in CI/offline scenarios:

- **`PRECOMPUTED_FCSUTI_FACTORS` was dead code.** The table and its `get_precomputed_fcsuti_factor` helper were defined but `get_fcsuti_inflation_factor` fell straight from a failed BLS fetch to the 4%/yr estimate. Users got a cruder fallback than the module advertised.

- **No BLS registration key plumbing.** `fetch_bls_cpi_series` posted unauthenticated, and unauthenticated callers are rate-limited to 25 queries per IP per day (≈ four `get_fcsuti_cpi` calls, since the composite pulls six component series). In CI or multi-run workflows the threshold calc silently slides to the 4%/yr estimate after the cap.

## Changes

### `spm_calculator/fcsuti_cpi.py`

- New resolution order in `get_fcsuti_inflation_factor`:
  1. Live BLS fetch
  2. Exact precomputed pair (from `PRECOMPUTED_FCSUTI_FACTORS`)
  3. Composed factor through a pivot year (inverts stored factors so we don't double the table size)
  4. 4%/yr estimate with a warning that makes the degradation visible

- `fetch_bls_cpi_series(..., registration_key=None)`: accepts an explicit key; falls back to `$BLS_API_KEY` from the environment. No key, no `registrationkey` field (rather than sending an empty string).

- `from_year == to_year` short-circuits to `1.0` before the API call.

### Tests

- New `tests/test_fcsuti_cpi.py` covers the three offline tiers (precomputed → composed → 4%), the registration-key plumbing (explicit param, env var, absent), and the direct/reverse precomputed-factor helper behavior.

## Test plan

- [x] `uv run pytest -x -q` → 100 passed, 16 skipped (was 87 / 16)
- [x] Documented offline resolution order visible in warnings

Fixes findings 8 and 15 from the bug hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
