### PR TITLE
Forecast improvements: horizon warning, actionable back-cast error, retain precision

### DIFF
--- a/spm_calculator/forecast.py
+++ b/spm_calculator/forecast.py
@@ -8,6 +8,7 @@ The BLS typically publishes thresholds with a 1-2 year lag, so forecasting
 is necessary for current and future year calculations.
 """
 
+import warnings
 from typing import Optional
 
 # Historical BLS published thresholds
@@ -81,6 +82,12 @@ CPI_PROJECTIONS = {
 # Default long-run inflation assumption
 DEFAULT_INFLATION = 0.020  # 2.0% Fed target
 
+# Forecasts compound inflation off the latest published year. Past this
+# horizon the cumulative drift from the hardcoded base is large enough
+# that callers should know they are past the region where the forecast
+# is even approximately reliable — we emit a RuntimeWarning.
+FORECAST_WARNING_HORIZON = 5
+
 
 def get_inflation_rate(year: int) -> float:
     """
@@ -135,20 +142,27 @@ def forecast_thresholds(
                          instead of projections.
 
     Returns:
-        Dict with forecasted threshold values by tenure type
+        Dict with forecasted threshold values by tenure type. Values
+        retain sub-dollar precision; the previous implementation cast
+        to ``int`` before composition with equivalence and geographic
+        adjustments, introducing ~$1 drift vs. the mathematically exact
+        product.
     """
+    available = sorted(HISTORICAL_THRESHOLDS.keys())
     if year <= LATEST_PUBLISHED_YEAR:
         if year in HISTORICAL_THRESHOLDS:
             return HISTORICAL_THRESHOLDS[year].copy()
-        else:
-            raise ValueError(
-                f"Year {year} not in historical data. "
-                f"Available: {sorted(HISTORICAL_THRESHOLDS.keys())}"
-            )
+        raise ValueError(
+            f"Year {year} is below the earliest supported year "
+            f"({available[0]}). Historical SPM thresholds are only "
+            f"available for {available[0]}–{LATEST_PUBLISHED_YEAR}."
+        )
 
     # Use latest published year as base
     if base_year is None:
         base_year = LATEST_PUBLISHED_YEAR
+
+    _maybe_warn_far_forecast(year, base_year)
 
     base_thresholds = HISTORICAL_THRESHOLDS[base_year]
 
@@ -159,13 +173,35 @@ def forecast_thresholds(
     else:
         inflation_factor = calculate_cumulative_inflation(base_year, year)
 
-    # Apply inflation to all tenure types
+    # Keep float precision through the forecast multiply. Downstream
+    # code composes this with `equiv_scale * geoadj`, so rounding to
+    # int early introduces up to ~$1 drift vs. the exact product.
     forecasted = {
-        tenure: int(round(value * inflation_factor))
+        tenure: float(value * inflation_factor)
         for tenure, value in base_thresholds.items()
     }
 
     return forecasted
+
+
+def _maybe_warn_far_forecast(year: int, base_year: int) -> None:
+    """Emit a RuntimeWarning once the forecast horizon exceeds N years.
+
+    Silently compounding decades of 2% inflation off a hardcoded 2024
+    base is not useful output; the warning gives downstream code a
+    chance to surface the uncertainty to users. `get_threshold_with_metadata`
+    also exposes this horizon via the returned dict.
+    """
+    horizon = year - base_year
+    if horizon > FORECAST_WARNING_HORIZON:
+        warnings.warn(
+            f"Forecasting SPM thresholds {horizon} years past the latest "
+            f"published year ({base_year}); values compound default "
+            f"inflation beyond the published CPI projection window "
+            f"({max(CPI_PROJECTIONS)}). Treat results as illustrative.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
 
 
 def get_thresholds(
@@ -254,6 +290,13 @@ def get_threshold_with_metadata(
         result["inflation_rate"] = (
             custom_inflation if custom_inflation else get_inflation_rate(year)
         )
+        # Tell callers whether we're past the point where the
+        # forecast is even approximately reliable. Matches the
+        # RuntimeWarning emitted by `forecast_thresholds`.
+        result["horizon_years"] = year - base_year
+        result["beyond_reliable_horizon"] = (
+            year - base_year
+        ) > FORECAST_WARNING_HORIZON
 
     return result
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -42,9 +42,7 @@ class TestForecastHorizonWarning:
             warnings.simplefilter("always")
             forecast_thresholds(target)
         matching = [
-            w
-            for w in caught
-            if "Forecasting SPM thresholds" in str(w.message)
+            w for w in caught if "Forecasting SPM thresholds" in str(w.message)
         ]
         assert matching, "Expected a RuntimeWarning past the horizon"
 
@@ -111,6 +109,6 @@ def test_cpi_projections_end_year_referenced_in_warning():
         warnings.simplefilter("always")
         forecast_thresholds(target)
     texts = [str(w.message) for w in caught]
-    assert any(str(end) in text for text in texts), (
-        f"Expected CPI projection end year {end} in warning"
-    )
+    assert any(
+        str(end) in text for text in texts
+    ), f"Expected CPI projection end year {end} in warning"

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,116 @@
+"""Tests for the forecast module.
+
+Covers:
+
+- The "far-future" RuntimeWarning (bug 9): silently compounding decades
+  of 2% inflation off a hardcoded base is not useful output.
+- The historical back-cast error message (bug 10): a clearer "earliest
+  supported year is 2015" rather than "Year 2014 not in historical data".
+- Sub-dollar precision (bug 16): `forecast_thresholds` no longer casts
+  to int before composition with equivalence and geographic adjustments.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from spm_calculator.forecast import (
+    CPI_PROJECTIONS,
+    FORECAST_WARNING_HORIZON,
+    HISTORICAL_THRESHOLDS,
+    LATEST_PUBLISHED_YEAR,
+    calculate_cumulative_inflation,
+    forecast_thresholds,
+    get_threshold_with_metadata,
+)
+
+
+class TestForecastHorizonWarning:
+    def test_short_horizon_is_silent(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            forecast_thresholds(LATEST_PUBLISHED_YEAR + 1)
+        assert not any(
+            "Forecasting SPM thresholds" in str(w.message) for w in caught
+        )
+
+    def test_far_horizon_warns_past_threshold(self):
+        target = LATEST_PUBLISHED_YEAR + FORECAST_WARNING_HORIZON + 1
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            forecast_thresholds(target)
+        matching = [
+            w
+            for w in caught
+            if "Forecasting SPM thresholds" in str(w.message)
+        ]
+        assert matching, "Expected a RuntimeWarning past the horizon"
+
+    def test_far_horizon_metadata_flag(self):
+        target = LATEST_PUBLISHED_YEAR + FORECAST_WARNING_HORIZON + 10
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            meta = get_threshold_with_metadata(target)
+        assert meta["beyond_reliable_horizon"] is True
+        assert meta["horizon_years"] == target - LATEST_PUBLISHED_YEAR
+
+    def test_near_horizon_metadata_flag_is_false(self):
+        target = LATEST_PUBLISHED_YEAR + 1
+        meta = get_threshold_with_metadata(target)
+        assert meta["beyond_reliable_horizon"] is False
+
+
+class TestBackCastErrorMessage:
+    def test_below_earliest_supported_year_message(self):
+        """Previously raised 'Year 2014 not in historical data'; now
+        explicitly references the earliest supported year."""
+        earliest = min(HISTORICAL_THRESHOLDS.keys())
+        with pytest.raises(
+            ValueError, match="below the earliest supported year"
+        ):
+            forecast_thresholds(earliest - 1)
+
+
+class TestForecastPrecision:
+    def test_precision_is_retained_through_float_return(self):
+        """Previously `int(round(...))` truncated sub-dollar precision
+        before downstream composition with equivalence and geographic
+        adjustments. Values now flow as floats so `base × scale ×
+        geoadj` matches the mathematically exact product."""
+        year = LATEST_PUBLISHED_YEAR + 1
+        base = HISTORICAL_THRESHOLDS[LATEST_PUBLISHED_YEAR]["renter"]
+        factor = calculate_cumulative_inflation(LATEST_PUBLISHED_YEAR, year)
+        expected = base * factor
+        forecast = forecast_thresholds(year)
+        assert forecast["renter"] == pytest.approx(expected)
+        # Concrete: the old int-round path returned an integer with
+        # zero fractional part; the new path retains precision past
+        # the decimal point.
+        assert isinstance(forecast["renter"], float)
+
+    def test_historical_year_still_returns_int_values(self):
+        """Historical published values stay as integers (the BLS
+        tables report whole-dollar thresholds); only the forecast
+        path keeps floats."""
+        values = forecast_thresholds(LATEST_PUBLISHED_YEAR)
+        for tenure, amount in values.items():
+            assert amount == int(amount), (
+                f"Published {tenure} threshold drifted from "
+                f"HISTORICAL_THRESHOLDS"
+            )
+
+
+def test_cpi_projections_end_year_referenced_in_warning():
+    """Sanity: the warning mentions the end of the CPI projection window
+    so callers know the 2%/yr extrapolation is not arbitrary."""
+    end = max(CPI_PROJECTIONS)
+    target = LATEST_PUBLISHED_YEAR + FORECAST_WARNING_HORIZON + 1
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        forecast_thresholds(target)
+    texts = [str(w.message) for w in caught]
+    assert any(str(end) in text for text in texts), (
+        f"Expected CPI projection end year {end} in warning"
+    )


### PR DESCRIPTION
## Summary

Three loose ends in the forecast path:

1. **No warning for far-future forecasts.** `SPMCalculator(year=2099)` silently compounded 75 years of 2% default inflation with no warning. Past the 2025–2030 CPI projection window the numbers are illustrative at best.

2. **Unhelpful back-cast error.** `forecast_thresholds(2014)` raised `"Year 2014 not in historical data. Available: [2015, ...]"`, which reads like an internal error.

3. **Sub-dollar precision lost.** `int(round(value * inflation_factor))` truncated precision before downstream composition with equivalence and geographic adjustments, creating ~$1 drift vs the exact product while the return type was `dict[str, float]` — misleading callers about the available precision.

## Changes

### `spm_calculator/forecast.py`

- New constant `FORECAST_WARNING_HORIZON = 5`. `forecast_thresholds` emits a `RuntimeWarning` once the target exceeds `LATEST_PUBLISHED_YEAR + horizon`, referencing the CPI projection window so callers know the 2%/yr extrapolation isn't arbitrary.
- `get_threshold_with_metadata` exposes `horizon_years` and `beyond_reliable_horizon` flags so UIs can surface the uncertainty.
- Back-cast error message now reads: `"Year X is below the earliest supported year (2015). Historical SPM thresholds are only available for 2015–2024."`
- Forecast path retains float precision; historical years still return integer whole-dollar BLS values.

## Test plan

- [x] `uv run pytest -x -q` → 95 passed, 16 skipped (was 87 / 16)
- [x] New `tests/test_forecast.py` covering:
  - Short-horizon forecasts stay silent
  - Past-horizon forecasts emit a `RuntimeWarning`
  - Metadata flags (`horizon_years`, `beyond_reliable_horizon`) match
  - Back-cast message cites the earliest supported year
  - Forecast values retain sub-dollar precision through composition
  - CPI projection window is mentioned in the warning

Fixes findings 9, 10, and 16 from the bug hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
