### PR TITLE
Map /us/spm-calculator/* on Vercel to the static-export root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd web && bun install --frozen-lockfile && NEXT_PUBLIC_BASE_PATH=/us/spm-calculator bun run build",
   "outputDirectory": "web/out",
-  "installCommand": "cd web && bun install --frozen-lockfile"
+  "installCommand": "cd web && bun install --frozen-lockfile",
+  "rewrites": [
+    {
+      "source": "/us/spm-calculator",
+      "destination": "/"
+    },
+    {
+      "source": "/us/spm-calculator/:path*",
+      "destination": "/:path*"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Next.js 16 static export with `basePath: /us/spm-calculator` emits files at `out/index.html` and `out/_next/*` — the basePath only rewrites URLs in the HTML, it doesn't nest the output under the basePath subdirectory. Without a rewrite, `spm-calculator.vercel.app` serves the HTML at `/` but the HTML links reference `/us/spm-calculator/_next/*` which 404 because nothing sits at that path.

Verified by `curl`:
- `spm-calculator.vercel.app/` → 200 (HTML with asset URLs prefixed by `/us/spm-calculator/`)
- `spm-calculator.vercel.app/us/spm-calculator/` → 404

The reverse-proxy from [`policyengine-app-v2#991`](https://github.com/PolicyEngine/policyengine-app-v2/pull/991) (`policyengine.org/us/spm-calculator/*` → `spm-calculator.vercel.app/us/spm-calculator/*`) therefore lands on 404.

## Fix

Add two rewrites to the spm-calculator Vercel config:

```json
{ "source": "/us/spm-calculator", "destination": "/" },
{ "source": "/us/spm-calculator/:path*", "destination": "/:path*" }
```

After this:
- `spm-calculator.vercel.app/us/spm-calculator/` → serves `out/index.html`
- `spm-calculator.vercel.app/us/spm-calculator/_next/foo.js` → serves `out/_next/foo.js`
- HTML links reference `/us/spm-calculator/_next/foo.js` → Vercel rewrites to `/_next/foo.js` → served
- End-to-end from `policyengine.org/us/spm-calculator/*` resolves cleanly once #991 merges

## Test plan

- [ ] Vercel preview on this PR serves the calculator at `<preview>.vercel.app/us/spm-calculator/`
- [ ] Asset paths in the served HTML resolve without 404
- [ ] Standalone `spm-calculator.vercel.app/` still works (root still hits the static `out/index.html`; the rewrites don't affect unmatched paths)
- [x] No Python package changes — `pyproject.toml` version unchanged, no PyPI republish

🤖 Generated with [Claude Code](https://claude.com/claude-code)