### PR TITLE
Also rewrite /us/spm-calculator/ (trailing slash) to root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
       "destination": "/"
     },
     {
+      "source": "/us/spm-calculator/",
+      "destination": "/"
+    },
+    {
       "source": "/us/spm-calculator/:path*",
       "destination": "/:path*"
     }


### PR DESCRIPTION
Follow-up to #19: that PR's rewrites handle `/us/spm-calculator` (no slash) and `/us/spm-calculator/foo` (at least one segment under the basePath), but the trailing-slash form `/us/spm-calculator/` falls in neither bucket.

Verified in production after #19 landed:

```
$ curl -o /dev/null -w "%{http_code}" https://spm-calculator.vercel.app/us/spm-calculator
200
$ curl -o /dev/null -w "%{http_code}" https://spm-calculator.vercel.app/us/spm-calculator/
404
```

Because `next.config.mjs` sets `trailingSlash: true`, Next emits asset URLs with the trailing slash and `next/link` generates them too — so this 404s real user navigation, not just a curl edge case.

Adds one explicit rewrite for `/us/spm-calculator/` → `/`.

## Test plan

- [x] Reproduced 404 in production after #19
- [ ] Vercel preview on this PR: `/us/spm-calculator/` → 200 with `out/index.html`
- [ ] End-to-end through `policyengine.org/us/spm-calculator/` (requires `policyengine-app-v2#991` to land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)