### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spm-calculator"
-version = "0.3.0"
+version = "0.3.1"
 description = "Calculate SPM (Supplemental Poverty Measure) thresholds for any US geography and year"
 readme = "README.md"
 license = "MIT"
@@ -15,6 +15,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -22,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "pandas>=2.0",
     "numpy>=1.24",


### PR DESCRIPTION
## Summary

Lower `requires-python` from `>=3.10` to `>=3.9` and expand CI matrices. Source is already 3.9-compatible (no PEP 604 unions, no `match`, no `StrEnum`, no PEP 695 generic class syntax), so this is a classifier + CI change only. Bumped version to 0.3.1.

## Motivation

`policyengine-us` is adding 3.9 support (PolicyEngine/policyengine-us#8035), and this was the last transitive dependency still gating 3.9 installs.

## Test plan

- [x] Fresh `python3.9 -m venv` + `pip install .` succeeds; `from spm_calculator import calculator, ce_threshold, geoadj, forecast, equivalence_scale, fcsuti_cpi` all import
- [ ] CI: `test` matrix passes on 3.9 through 3.14 (existing tests unchanged)
