### PR TITLE
Reconstruct Census ASEC SPM unit IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,44 @@ Official metro thresholds are bundled with the package. For custom ACS-based
 geographies like states, counties, congressional districts, PUMAs, and tracts,
 set `CENSUS_API_KEY` to fetch current median rents.
 
+### SPM unit IDs
+
+If your data does not already include Census SPM resource-unit IDs, use
+`spm_unit_id` to create person-level IDs before calculating thresholds:
+
+```python
+from spm_calculator import spm_unit_id
+
+ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+```
+
+The function preserves native `person_spm_unit_id`, `spm_unit_id`, or `SPM_ID`
+columns when present. Otherwise, it reconstructs units from the smallest
+available person-level inputs:
+
+| Input class | Columns recognized by default |
+|-------------|-------------------------------|
+| Required | `household_id`, `person_household_id`, `H_SEQ`, or `PH_SEQ` |
+| Strongly recommended | `family_id`, `person_family_id`, or `PF_SEQ`; `age` or `A_AGE` |
+| Person pointers | `line_number`, `person_line_number`, or `A_LINENO`; `parent_id`, `mother_id`, `father_id`, `PEPAR1`, `PEPAR2`; `spouse_id` or `A_SPOUSE`; `unmarried_partner_id`, `partner_id`, `cohabiting_partner_id`, or `PECOHAB` |
+| Census SPM assignment flags | `SPM_WFOSTER22`, `SPM_WUI_LT15`, and `SPM_WNEWPARENT`; `SPM_WCOHABIT` is used only when no direct cohabiting partner pointer such as `PECOHAB` is available |
+| Generic fallback flags | `relationship_to_head`, `family_relationship`, or `A_FAMREL`; `is_foster_child` or `foster_child` |
+
+Diagnostics describe assignment provenance and missing recommended inputs; they
+do not summarize the resulting unit distribution.
+
+For parity checks against Census/native IDs or published thresholds:
+
+```python
+from spm_calculator import spm_threshold_match, spm_unit_id_match
+
+id_report = spm_unit_id_match(persons)
+threshold_report = spm_threshold_match(calculated, reference, atol=1.0)
+```
+
+The optional ASEC parity tests run against a real Census CPS ASEC HDFStore when
+`SPM_CALCULATOR_ASEC_H5=/path/to/census_cps_2024.h5` is set.
+
 ## Supported Geographies
 
 - `nation` - National average

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -7,4 +7,5 @@ chapters:
       - file: api/calculator
       - file: api/geoadj
       - file: api/equivalence_scale
+      - file: api/units
   - file: validation

--- a/docs/api/units.md
+++ b/docs/api/units.md
@@ -1,0 +1,77 @@
+# SPM Unit IDs
+
+Helpers for reconstructing SPM resource-unit membership from person records.
+
+## spm_unit_id
+
+```python
+from spm_calculator import spm_unit_id
+
+ids = spm_unit_id(persons)
+ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+```
+
+`spm_unit_id` returns a person-level `pandas.Series` aligned to `persons`.
+If native IDs are present, it preserves `person_spm_unit_id`, `spm_unit_id`, or
+`SPM_ID` exactly. Otherwise, it infers unit membership within each household.
+
+### Inputs
+
+Only a household ID is required. More inputs improve fidelity.
+
+| Input class | Columns recognized by default |
+|-------------|-------------------------------|
+| Required | `household_id`, `person_household_id`, `H_SEQ`, or `PH_SEQ` |
+| Family grouping | `family_id`, `person_family_id`, or `PF_SEQ` |
+| Age | `age` or `A_AGE` |
+| Person line number | `line_number`, `person_line_number`, or `A_LINENO` |
+| Parent pointers | `parent_id`, `mother_id`, `father_id`, `PEPAR1`, or `PEPAR2` |
+| Partner and spouse pointers | `unmarried_partner_id`, `partner_id`, `cohabiting_partner_id`, `PECOHAB`, `spouse_id`, or `A_SPOUSE` |
+| Census SPM assignment flags | `SPM_WFOSTER22`, `SPM_WUI_LT15`, and `SPM_WNEWPARENT`; `SPM_WCOHABIT` is used only when no direct cohabiting partner pointer such as `PECOHAB` is available |
+| Generic relationship fields | `relationship_to_head`, `family_relationship`, `A_FAMREL`, `is_foster_child`, or `foster_child` |
+
+Pointer columns are matched to `line_number` when it is present; otherwise they
+are matched to `person_id`.
+
+### Diagnostics
+
+With `diagnostics=True`, the function returns:
+
+```python
+{
+    "method": "native_spm_id" | "census_relationship_rules" | "fallback_household_rules",
+    "native_id_column": "SPM_ID" | None,
+    "used_columns": [...],
+    "missing_recommended_columns": [...],
+    "fallback_rules_used": [...],
+    "confidence": "native" | "rule_based" | "approximate",
+}
+```
+
+Diagnostics describe assignment provenance only. They intentionally do not
+report unit counts, sizes, child-only units, or other unit profile summaries.
+
+### Unsupported Cases
+
+When the input lacks a direct partner pointer, multiple unrelated cohabiting
+SPM units in the same household can be ambiguous. `SPM_WCOHABIT` identifies
+people in cohabiting SPM units but does not distinguish multiple cohabiting
+units inside the same household. Exact reconstruction of those cases requires
+`PECOHAB` or an equivalent partner pointer.
+
+## spm_unit_id_match
+
+```python
+from spm_calculator import spm_unit_id_match
+
+report = spm_unit_id_match(persons, reference_spm_unit_id="SPM_ID")
+```
+
+`spm_unit_id_match` compares assignments within household up to arbitrary
+relabeling of unit IDs. If `predicted_spm_unit_id` is omitted, it infers IDs
+with `spm_unit_id` while disabling native-ID preservation.
+
+The optional ASEC parity test runs when `SPM_CALCULATOR_ASEC_H5` points to a
+Census CPS ASEC HDFStore. With the full raw 2025 CPS ASEC person columns for
+the 2024 data year, including `PECOHAB`, the default reconstruction matched
+all 55,762 household partitions.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -70,6 +70,24 @@ assert abs(spm_equivalence_scale(1, 0) - 0.4634630568) < 1e-9
 assert abs(spm_equivalence_scale(2, 0) - 0.6534829100) < 1e-9
 ```
 
+## SPM Unit ID Validation
+
+SPM unit IDs are arbitrary labels, so validation compares the person partition
+within each household rather than the literal ID values. `spm_unit_id_match`
+reports household and person-weighted household match rates.
+
+An optional ASEC parity test runs when `SPM_CALCULATOR_ASEC_H5` points to a
+Census CPS ASEC HDFStore:
+
+```bash
+SPM_CALCULATOR_ASEC_H5=/path/to/census_cps_2024.h5 pytest tests/test_asec_parity.py
+```
+
+The default floor is a 99% household partition match rate. If the HDFStore
+contains `PECOHAB`, the test requires exact partition parity. With the full raw
+2025 CPS ASEC person columns for the 2024 data year, including `PECOHAB`, the
+default reconstruction matched all 55,762 household partitions.
+
 ## Running Validation Tests
 
 ```bash

--- a/spm_calculator/__init__.py
+++ b/spm_calculator/__init__.py
@@ -55,6 +55,8 @@ from .geoadj import (
     get_metro_rent_index,
     list_metro_areas,
 )
+from .units import spm_unit_id
+from .validation import spm_threshold_match, spm_unit_id_match
 
 try:
     from importlib.metadata import (
@@ -104,4 +106,7 @@ __all__ = [
     "get_available_years",
     "get_latest_published_year",
     "HISTORICAL_THRESHOLDS",
+    "spm_unit_id",
+    "spm_unit_id_match",
+    "spm_threshold_match",
 ]

--- a/spm_calculator/units.py
+++ b/spm_calculator/units.py
@@ -1,0 +1,580 @@
+"""SPM resource-unit membership helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+def spm_unit_id(
+    persons: pd.DataFrame,
+    *,
+    household_id: str | None = "household_id",
+    person_id: str | None = "person_id",
+    line_number: str | None = "line_number",
+    age: str | None = "age",
+    family_id: str | None = "family_id",
+    relationship_to_head: str | None = "relationship_to_head",
+    unmarried_partner_id: str | None = "unmarried_partner_id",
+    spouse_id: str | None = "spouse_id",
+    parent_id: str | None = "parent_id",
+    mother_id: str | None = "mother_id",
+    father_id: str | None = "father_id",
+    foster_child: str | None = "is_foster_child",
+    spm_cohabiting_unit: str | None = "spm_cohabiting_unit",
+    spm_foster_child_unit: str | None = "spm_foster_child_unit",
+    spm_unrelated_child_unit: str | None = "spm_unrelated_child_unit",
+    spm_new_parent_unit: str | None = "spm_new_parent_unit",
+    native_person_spm_unit_id: str | None = "person_spm_unit_id",
+    native_spm_unit_id: str | None = "spm_unit_id",
+    diagnostics: bool = False,
+) -> pd.Series | tuple[pd.Series, dict[str, Any]]:
+    """Return person-level SPM resource-unit IDs.
+
+    If the input already includes native SPM IDs, those IDs are preserved.
+    Otherwise, this applies a best-effort implementation of Census-style SPM
+    resource-unit membership: family members share a unit, cohabiting partners
+    share a unit when partner links are present, foster children under 22 and
+    unrelated children under 15 are attached to the household reference unit,
+    and other people remain in separate units.
+
+    The function returns a Series aligned to ``persons`` and does not mutate the
+    input DataFrame.
+    """
+    native_column = _resolve_column(
+        persons,
+        native_person_spm_unit_id,
+        ("person_spm_unit_id", "SPM_ID"),
+    )
+    if native_column is None:
+        native_column = _resolve_column(
+            persons,
+            native_spm_unit_id,
+            ("spm_unit_id",),
+        )
+
+    if native_column is not None:
+        ids = persons[native_column].copy()
+        ids.name = "spm_unit_id"
+        info = {
+            "method": "native_spm_id",
+            "native_id_column": native_column,
+            "used_columns": [native_column],
+            "missing_recommended_columns": [],
+            "fallback_rules_used": [],
+            "confidence": "native",
+        }
+        return (ids, info) if diagnostics else ids
+
+    ids, info = _infer_spm_unit_id(
+        persons,
+        household_id=household_id,
+        person_id=person_id,
+        line_number=line_number,
+        age=age,
+        family_id=family_id,
+        relationship_to_head=relationship_to_head,
+        unmarried_partner_id=unmarried_partner_id,
+        spouse_id=spouse_id,
+        parent_id=parent_id,
+        mother_id=mother_id,
+        father_id=father_id,
+        foster_child=foster_child,
+        spm_cohabiting_unit=spm_cohabiting_unit,
+        spm_foster_child_unit=spm_foster_child_unit,
+        spm_unrelated_child_unit=spm_unrelated_child_unit,
+        spm_new_parent_unit=spm_new_parent_unit,
+    )
+    return (ids, info) if diagnostics else ids
+
+
+def _infer_spm_unit_id(
+    persons: pd.DataFrame,
+    *,
+    household_id: str | None,
+    person_id: str | None,
+    line_number: str | None,
+    age: str | None,
+    family_id: str | None,
+    relationship_to_head: str | None,
+    unmarried_partner_id: str | None,
+    spouse_id: str | None,
+    parent_id: str | None,
+    mother_id: str | None,
+    father_id: str | None,
+    foster_child: str | None,
+    spm_cohabiting_unit: str | None,
+    spm_foster_child_unit: str | None,
+    spm_unrelated_child_unit: str | None,
+    spm_new_parent_unit: str | None,
+) -> tuple[pd.Series, dict[str, Any]]:
+    household_column = _resolve_column(
+        persons,
+        household_id,
+        ("household_id", "person_household_id", "H_SEQ", "PH_SEQ"),
+        required=True,
+    )
+    person_column = _resolve_column(
+        persons,
+        person_id,
+        ("person_id", "P_ID", "P_SEQ", "PERIDNUM"),
+    )
+    line_column = _resolve_column(
+        persons,
+        line_number,
+        ("line_number", "person_line_number", "A_LINENO"),
+    )
+    age_column = _resolve_column(persons, age, ("age", "A_AGE"))
+    family_column = _resolve_column(
+        persons,
+        family_id,
+        ("family_id", "person_family_id", "PF_SEQ"),
+    )
+    relationship_column = _resolve_column(
+        persons,
+        relationship_to_head,
+        ("relationship_to_head", "family_relationship", "A_FAMREL"),
+    )
+    partner_column = _resolve_column(
+        persons,
+        unmarried_partner_id,
+        (
+            "unmarried_partner_id",
+            "partner_id",
+            "cohabiting_partner_id",
+            "PECOHAB",
+        ),
+    )
+    spouse_column = _resolve_column(
+        persons,
+        spouse_id,
+        ("spouse_id", "spouse_person_id", "A_SPOUSE"),
+    )
+    foster_column = _resolve_column(
+        persons,
+        foster_child,
+        ("is_foster_child", "foster_child"),
+    )
+    parent_columns = [
+        column
+        for column in (
+            _resolve_column(persons, parent_id, ("parent_id",)),
+            _resolve_column(
+                persons,
+                mother_id,
+                ("mother_id", "first_parent_id", "PEPAR1"),
+            ),
+            _resolve_column(
+                persons,
+                father_id,
+                ("father_id", "second_parent_id", "PEPAR2"),
+            ),
+        )
+        if column is not None
+    ]
+    parent_columns = list(dict.fromkeys(parent_columns))
+    cohabiting_unit_column = _resolve_column(
+        persons,
+        spm_cohabiting_unit,
+        ("spm_cohabiting_unit", "SPM_WCOHABIT"),
+    )
+    foster_child_unit_column = _resolve_column(
+        persons,
+        spm_foster_child_unit,
+        ("spm_foster_child_unit", "SPM_WFOSTER22"),
+    )
+    unrelated_child_unit_column = _resolve_column(
+        persons,
+        spm_unrelated_child_unit,
+        ("spm_unrelated_child_unit", "SPM_WUI_LT15"),
+    )
+    new_parent_unit_column = _resolve_column(
+        persons,
+        spm_new_parent_unit,
+        ("spm_new_parent_unit", "SPM_WNEWPARENT"),
+    )
+    spm_unit_flag_columns = {
+        "merge_census_foster_under_22_flags": foster_child_unit_column,
+        "merge_census_unrelated_under_15_flags": unrelated_child_unit_column,
+        "merge_census_new_parent_flags": new_parent_unit_column,
+    }
+    if cohabiting_unit_column is not None and partner_column is None:
+        spm_unit_flag_columns["merge_census_cohabiting_unit_flags"] = (
+            cohabiting_unit_column
+        )
+    spm_unit_flag_columns = {
+        rule: column
+        for rule, column in spm_unit_flag_columns.items()
+        if column is not None
+    }
+    has_linkage_columns = (
+        parent_columns
+        or partner_column is not None
+        or spouse_column is not None
+        or foster_column is not None
+        or spm_unit_flag_columns
+    )
+    pointer_column = line_column or person_column
+    pointer_work_column = (
+        "_line_number"
+        if pointer_column is not None and pointer_column == line_column
+        else "_person"
+    )
+
+    n = len(persons)
+    parents = list(range(n))
+
+    def find(position: int) -> int:
+        while parents[position] != position:
+            parents[position] = parents[parents[position]]
+            position = parents[position]
+        return position
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parents[right_root] = left_root
+
+    work = pd.DataFrame(
+        {
+            "_position": np.arange(n, dtype=int),
+            "_household": persons[household_column].to_numpy(),
+        },
+        index=persons.index,
+    )
+    if person_column is not None:
+        work["_person"] = persons[person_column].to_numpy()
+    if line_column is not None:
+        work["_line_number"] = persons[line_column].to_numpy()
+    if age_column is not None:
+        work["_age"] = pd.to_numeric(
+            persons[age_column],
+            errors="coerce",
+        )
+    if family_column is not None:
+        work["_family"] = persons[family_column].to_numpy()
+    if relationship_column is not None:
+        work["_relationship"] = _normalize_relationship(
+            persons[relationship_column]
+        )
+    if foster_column is not None:
+        work["_foster_child"] = _coerce_bool(persons[foster_column])
+    for rule_name, column in spm_unit_flag_columns.items():
+        work[f"_{rule_name}"] = _coerce_bool(persons[column])
+
+    fallback_rules_used: set[str] = set()
+
+    for _, household_rows in work.groupby("_household", sort=False):
+        positions = household_rows["_position"].to_numpy(dtype=int)
+        if len(positions) == 0:
+            continue
+
+        primary_anchor: int | None = None
+
+        if "_family" in household_rows:
+            family_rows = household_rows[household_rows["_family"].notna()]
+            for _, group in family_rows.groupby("_family", sort=False):
+                group_positions = group["_position"].to_numpy(dtype=int)
+                _union_all(group_positions, union)
+
+            if "_relationship" in household_rows:
+                head_rows = household_rows[
+                    household_rows["_relationship"].eq("head")
+                ]
+                if not head_rows.empty:
+                    primary_anchor = find(int(head_rows["_position"].iloc[0]))
+            if primary_anchor is None:
+                primary_anchor = find(int(positions[0]))
+        elif "_relationship" in household_rows:
+            primary_rows = household_rows[
+                household_rows["_relationship"].isin(
+                    {"head", "spouse", "child"}
+                )
+            ]
+            primary_positions = primary_rows["_position"].to_numpy(dtype=int)
+            _union_all(primary_positions, union)
+            if len(primary_positions) > 0:
+                primary_anchor = find(int(primary_positions[0]))
+        else:
+            if not has_linkage_columns:
+                _union_all(positions, union)
+                fallback_rules_used.add("household_level_fallback")
+            primary_anchor = find(int(positions[0]))
+
+        if primary_anchor is None:
+            continue
+
+        if (
+            "_relationship" in household_rows
+            and "_age" in household_rows
+            and unrelated_child_unit_column is None
+        ):
+            unrelated_children = household_rows[
+                household_rows["_relationship"].eq("other")
+                & household_rows["_age"].lt(15)
+            ]["_position"].to_numpy(dtype=int)
+            if len(unrelated_children) > 0:
+                fallback_rules_used.add(
+                    "attach_unrelated_under_15_to_reference_unit"
+                )
+            for position in unrelated_children:
+                union(primary_anchor, int(position))
+
+        if (
+            "_foster_child" in household_rows
+            and "_age" in household_rows
+            and foster_child_unit_column is None
+        ):
+            foster_children = household_rows[
+                household_rows["_foster_child"] & household_rows["_age"].lt(22)
+            ]["_position"].to_numpy(dtype=int)
+            if len(foster_children) > 0:
+                fallback_rules_used.add(
+                    "attach_foster_under_22_to_reference_unit"
+                )
+            for position in foster_children:
+                union(primary_anchor, int(position))
+
+    for rule_name in spm_unit_flag_columns:
+        flag_column = f"_{rule_name}"
+        flagged_rows = work[work[flag_column]]
+        for _, group in flagged_rows.groupby("_household", sort=False):
+            positions = group["_position"].to_numpy(dtype=int)
+            if len(positions) < 2:
+                continue
+            _union_all(positions, union)
+            fallback_rules_used.add(rule_name)
+
+    if pointer_column is not None and partner_column is not None:
+        person_lookup = {
+            (row["_household"], row[pointer_work_column]): int(
+                row["_position"]
+            )
+            for _, row in work.iterrows()
+        }
+        for row_position, partner_value in enumerate(persons[partner_column]):
+            if pd.isna(partner_value):
+                continue
+            household_value = work["_household"].iloc[row_position]
+            partner_position = person_lookup.get(
+                (household_value, partner_value)
+            )
+            if partner_position is None:
+                continue
+            union(row_position, partner_position)
+            fallback_rules_used.add("link_unmarried_partners")
+
+    if pointer_column is not None and spouse_column is not None:
+        person_lookup = {
+            (row["_household"], row[pointer_work_column]): int(
+                row["_position"]
+            )
+            for _, row in work.iterrows()
+        }
+        for row_position, spouse_value in enumerate(persons[spouse_column]):
+            if pd.isna(spouse_value):
+                continue
+            household_value = work["_household"].iloc[row_position]
+            spouse_position = person_lookup.get(
+                (household_value, spouse_value)
+            )
+            if spouse_position is None:
+                continue
+            union(row_position, spouse_position)
+            fallback_rules_used.add("link_spouses")
+
+    if pointer_column is not None and parent_columns:
+        person_lookup = {
+            (row["_household"], row[pointer_work_column]): int(
+                row["_position"]
+            )
+            for _, row in work.iterrows()
+        }
+        for parent_column_name in parent_columns:
+            for row_position, parent_value in enumerate(
+                persons[parent_column_name]
+            ):
+                if pd.isna(parent_value):
+                    continue
+                household_value = work["_household"].iloc[row_position]
+                parent_position = person_lookup.get(
+                    (household_value, parent_value)
+                )
+                if parent_position is None:
+                    continue
+                union(row_position, parent_position)
+                fallback_rules_used.add("link_parent_child")
+
+    root_to_id: dict[int, int] = {}
+    values: list[int] = []
+    for position in range(n):
+        root = find(position)
+        if root not in root_to_id:
+            root_to_id[root] = len(root_to_id)
+        values.append(root_to_id[root])
+
+    used_columns = [
+        column
+        for column in (
+            household_column,
+            person_column,
+            line_column,
+            age_column,
+            family_column,
+            relationship_column,
+            partner_column,
+            spouse_column,
+            foster_column,
+            *parent_columns,
+            *spm_unit_flag_columns.values(),
+        )
+        if column is not None
+    ]
+    used_columns = list(dict.fromkeys(used_columns))
+    missing_recommended = [
+        name
+        for name, column in {
+            "age": age_column,
+            "family_id": family_column,
+            "relationship_to_head": relationship_column,
+            "unmarried_partner_id": partner_column,
+            "spouse_id": spouse_column,
+            "line_number": line_column,
+            "parent_id": parent_columns or None,
+            "foster_child": foster_column,
+            "spm_cohabiting_unit": spm_unit_flag_columns.get(
+                "merge_census_cohabiting_unit_flags"
+            )
+            or partner_column,
+            "spm_foster_child_unit": spm_unit_flag_columns.get(
+                "merge_census_foster_under_22_flags"
+            ),
+            "spm_unrelated_child_unit": spm_unit_flag_columns.get(
+                "merge_census_unrelated_under_15_flags"
+            ),
+            "spm_new_parent_unit": spm_unit_flag_columns.get(
+                "merge_census_new_parent_flags"
+            ),
+        }.items()
+        if column is None
+    ]
+
+    method = (
+        "census_relationship_rules"
+        if (
+            family_column is not None
+            or relationship_column is not None
+            or parent_columns
+            or partner_column is not None
+            or spouse_column is not None
+            or spm_unit_flag_columns
+        )
+        else "fallback_household_rules"
+    )
+    confidence = (
+        "rule_based"
+        if method == "census_relationship_rules"
+        else "approximate"
+    )
+    info = {
+        "method": method,
+        "native_id_column": None,
+        "used_columns": used_columns,
+        "missing_recommended_columns": missing_recommended,
+        "fallback_rules_used": sorted(fallback_rules_used),
+        "confidence": confidence,
+    }
+    return pd.Series(values, index=persons.index, name="spm_unit_id"), info
+
+
+def _resolve_column(
+    frame: pd.DataFrame,
+    requested: str | None,
+    candidates: tuple[str, ...],
+    *,
+    required: bool = False,
+) -> str | None:
+    if requested is None:
+        if required:
+            raise KeyError(f"Missing required column; tried {candidates}")
+        return None
+    if requested in frame.columns:
+        return requested
+    if requested not in candidates:
+        raise KeyError(f"Column '{requested}' is not present")
+    for candidate in candidates:
+        if candidate in frame.columns:
+            return candidate
+    if required:
+        tried = ", ".join(dict.fromkeys((requested, *candidates)))
+        raise KeyError(f"Missing required column; tried {tried}")
+    return None
+
+
+def _normalize_relationship(values: pd.Series) -> pd.Series:
+    numeric = pd.to_numeric(values, errors="coerce")
+    unique_numeric = set(numeric.dropna().astype(int).unique().tolist())
+    if unique_numeric and unique_numeric.issubset({0, 1, 2, 3, 4}):
+        if 4 in unique_numeric:
+            mapped = numeric.map({1: "head", 2: "spouse", 3: "child"})
+        elif 0 in unique_numeric:
+            mapped = numeric.map({0: "head", 1: "spouse", 2: "child"})
+        else:
+            mapped = numeric.map({1: "head", 2: "spouse", 3: "child"})
+        return mapped.fillna("other")
+
+    normalized = values.astype(str).str.strip().str.lower()
+    result = pd.Series("other", index=values.index, dtype=object)
+    result.loc[
+        normalized.isin(
+            {
+                "head",
+                "householder",
+                "reference person",
+                "self",
+            }
+        )
+    ] = "head"
+    result.loc[
+        normalized.isin(
+            {
+                "spouse",
+                "wife",
+                "husband",
+                "partner",
+                "unmarried partner",
+            }
+        )
+    ] = "spouse"
+    result.loc[
+        normalized.isin(
+            {
+                "child",
+                "own child",
+                "son",
+                "daughter",
+                "stepchild",
+                "foster child",
+            }
+        )
+    ] = "child"
+    return result
+
+
+def _coerce_bool(values: pd.Series) -> pd.Series:
+    if values.dtype == bool:
+        return values.fillna(False)
+    numeric = pd.to_numeric(values, errors="coerce")
+    normalized = values.astype(str).str.strip().str.lower()
+    return numeric.eq(1) | normalized.isin({"true", "t", "yes", "y"})
+
+
+def _union_all(values: np.ndarray, union: Any) -> None:
+    if len(values) == 0:
+        return
+    first = int(values[0])
+    for value in values[1:]:
+        union(first, int(value))

--- a/spm_calculator/validation.py
+++ b/spm_calculator/validation.py
@@ -1,0 +1,184 @@
+"""Validation helpers for SPM IDs and thresholds."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .units import _resolve_column, spm_unit_id
+
+
+def spm_unit_id_match(
+    persons: pd.DataFrame,
+    *,
+    reference_spm_unit_id: str = "SPM_ID",
+    predicted_spm_unit_id: str | pd.Series | np.ndarray | None = None,
+    household_id: str = "household_id",
+    max_mismatching_household_ids: int = 10,
+    **spm_unit_id_kwargs: Any,
+) -> dict[str, Any]:
+    """Compare SPM unit assignments to reference IDs within households.
+
+    Unit IDs are arbitrary labels, so this validates that each household's
+    person partition matches the reference partition after relabeling.
+    If ``predicted_spm_unit_id`` is not supplied, IDs are inferred with
+    ``spm_unit_id`` while disabling native-ID preservation.
+    """
+    household_column = _resolve_column(
+        persons,
+        household_id,
+        ("household_id", "person_household_id", "H_SEQ", "PH_SEQ"),
+        required=True,
+    )
+    reference_column = _resolve_column(
+        persons,
+        reference_spm_unit_id,
+        ("SPM_ID", "person_spm_unit_id", "spm_unit_id"),
+        required=True,
+    )
+    reference = persons[reference_column]
+
+    if predicted_spm_unit_id is None:
+        inference_kwargs = dict(spm_unit_id_kwargs)
+        inference_kwargs.setdefault("household_id", household_column)
+        inference_kwargs.setdefault("native_person_spm_unit_id", None)
+        inference_kwargs.setdefault("native_spm_unit_id", None)
+        predicted = spm_unit_id(persons, **inference_kwargs)
+        if isinstance(predicted, tuple):
+            predicted = predicted[0]
+        predicted_source = "inferred"
+    elif isinstance(predicted_spm_unit_id, str):
+        predicted = persons[predicted_spm_unit_id]
+        predicted_source = predicted_spm_unit_id
+    else:
+        predicted = pd.Series(
+            predicted_spm_unit_id,
+            index=persons.index,
+            name="predicted_spm_unit_id",
+        )
+        predicted_source = "provided_array"
+
+    work = pd.DataFrame(
+        {
+            "household_id": persons[household_column],
+            "reference": reference,
+            "predicted": predicted,
+        },
+        index=persons.index,
+    )
+
+    matching_households = 0
+    matching_persons = 0
+    mismatching_household_ids: list[Any] = []
+    for household_value, household_rows in work.groupby(
+        "household_id",
+        sort=False,
+    ):
+        household_match = _canonical_partition(
+            household_rows["reference"]
+        ) == _canonical_partition(household_rows["predicted"])
+        if household_match:
+            matching_households += 1
+            matching_persons += len(household_rows)
+            continue
+        if len(mismatching_household_ids) < max_mismatching_household_ids:
+            mismatching_household_ids.append(household_value)
+
+    total_households = int(work["household_id"].nunique(dropna=False))
+    total_persons = int(len(work))
+    mismatching_households = total_households - matching_households
+    return {
+        "match": mismatching_households == 0,
+        "reference_column": reference_column,
+        "predicted_source": predicted_source,
+        "household_column": household_column,
+        "households": total_households,
+        "matching_households": int(matching_households),
+        "mismatching_households": int(mismatching_households),
+        "household_match_rate": _safe_rate(
+            matching_households,
+            total_households,
+        ),
+        "persons": total_persons,
+        "persons_in_matching_households": int(matching_persons),
+        "person_weighted_household_match_rate": _safe_rate(
+            matching_persons,
+            total_persons,
+        ),
+        "mismatching_household_ids": mismatching_household_ids,
+    }
+
+
+def spm_threshold_match(
+    calculated: pd.Series | np.ndarray | list[float],
+    reference: pd.Series | np.ndarray | list[float],
+    *,
+    rtol: float = 1e-4,
+    atol: float = 1.0,
+    max_mismatching_indices: int = 10,
+) -> dict[str, Any]:
+    """Compare calculated thresholds to reference values within tolerance."""
+    calculated_series = _as_numeric_series(calculated)
+    reference_series = _as_numeric_series(reference)
+    if len(calculated_series) != len(reference_series):
+        raise ValueError("calculated and reference must have the same length")
+
+    reference_series = pd.Series(
+        reference_series.to_numpy(),
+        index=calculated_series.index,
+    )
+    calculated_values = calculated_series.to_numpy(dtype=float)
+    reference_values = reference_series.to_numpy(dtype=float)
+    matches = np.isclose(
+        calculated_values,
+        reference_values,
+        rtol=rtol,
+        atol=atol,
+        equal_nan=False,
+    )
+    abs_error = np.abs(calculated_values - reference_values)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        rel_error = np.where(
+            reference_values != 0,
+            abs_error / np.abs(reference_values),
+            np.nan,
+        )
+
+    mismatching_index = calculated_series.index[~matches]
+    mismatching_indices = list(
+        mismatching_index[:max_mismatching_indices].tolist()
+    )
+    n = len(calculated_series)
+    matching = int(matches.sum())
+    return {
+        "match": bool(matches.all()),
+        "rtol": float(rtol),
+        "atol": float(atol),
+        "values": int(n),
+        "matching_values": matching,
+        "mismatching_values": int(n - matching),
+        "match_rate": _safe_rate(matching, n),
+        "max_abs_error": float(np.nanmax(abs_error)) if n else 0.0,
+        "max_rel_error": float(np.nanmax(rel_error)) if n else 0.0,
+        "mismatching_indices": mismatching_indices,
+    }
+
+
+def _canonical_partition(values: pd.Series) -> tuple[int, ...]:
+    codes, _ = pd.factorize(values, sort=False)
+    return tuple(int(code) for code in codes)
+
+
+def _as_numeric_series(
+    values: pd.Series | np.ndarray | list[float],
+) -> pd.Series:
+    series = values if isinstance(values, pd.Series) else pd.Series(values)
+    return pd.to_numeric(series, errors="coerce")
+
+
+def _safe_rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 1.0
+    return float(numerator / denominator)

--- a/tests/test_asec_parity.py
+++ b/tests/test_asec_parity.py
@@ -1,0 +1,103 @@
+"""Optional parity checks against a real Census CPS ASEC HDFStore."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from spm_calculator import (
+    SPMCalculator,
+    spm_equivalence_scale,
+    spm_threshold_match,
+    spm_unit_id_match,
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("SPM_CALCULATOR_ASEC_H5"),
+    reason=(
+        "Set SPM_CALCULATOR_ASEC_H5 to a Census CPS ASEC HDFStore to run "
+        "full ASEC parity checks"
+    ),
+)
+
+
+def _load_asec_tables() -> tuple[pd.DataFrame, pd.DataFrame]:
+    pytest.importorskip("tables")
+    path = Path(os.environ["SPM_CALCULATOR_ASEC_H5"]).expanduser()
+    with pd.HDFStore(path) as store:
+        return store["person"], store["spm_unit"]
+
+
+def test_asec_spm_unit_id_inference_matches_census_above_floor():
+    person, _ = _load_asec_tables()
+
+    report = spm_unit_id_match(
+        person,
+        household_id="PH_SEQ",
+        reference_spm_unit_id="SPM_ID",
+    )
+
+    min_household_match_rate = float(
+        os.environ.get("SPM_CALCULATOR_ASEC_ID_MATCH_FLOOR", "0.99")
+    )
+    assert report["household_match_rate"] >= min_household_match_rate, report
+    if "PECOHAB" in person.columns:
+        assert report["match"], report
+
+
+def test_asec_thresholds_match_census_within_tolerance():
+    _, spm_unit = _load_asec_tables()
+
+    calculator = SPMCalculator(year=2024)
+    base_thresholds = calculator.get_base_thresholds()
+    tenure = (
+        pd.to_numeric(
+            spm_unit["SPM_TENMORTSTATUS"],
+            errors="coerce",
+        )
+        .fillna(3)
+        .astype(int)
+        .map(
+            {
+                1: "owner_with_mortgage",
+                2: "owner_without_mortgage",
+                3: "renter",
+            }
+        )
+        .fillna("renter")
+    )
+    calculated = (
+        np.array([base_thresholds[value] for value in tenure], dtype=float)
+        * spm_equivalence_scale(
+            pd.to_numeric(
+                spm_unit["SPM_NUMADULTS"],
+                errors="coerce",
+            )
+            .fillna(0)
+            .to_numpy(dtype=float),
+            pd.to_numeric(
+                spm_unit["SPM_NUMKIDS"],
+                errors="coerce",
+            )
+            .fillna(0)
+            .to_numpy(dtype=float),
+        )
+        * pd.to_numeric(
+            spm_unit["SPM_GEOADJ"],
+            errors="coerce",
+        )
+        .fillna(1)
+        .to_numpy(dtype=float)
+    )
+
+    report = spm_threshold_match(
+        calculated,
+        spm_unit["SPM_POVTHRESHOLD"],
+        atol=1.0,
+        rtol=1e-4,
+    )
+    assert report["match"], report

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,239 @@
+"""Tests for SPM resource-unit membership helpers."""
+
+import pandas as pd
+
+from spm_calculator import spm_unit_id
+
+
+def test_spm_unit_id_preserves_native_person_spm_unit_id():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "household_id": [10, 10, 20],
+            "person_spm_unit_id": [100, 100, 200],
+        },
+        index=["a", "b", "c"],
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.tolist() == [100, 100, 200]
+    assert ids.index.tolist() == ["a", "b", "c"]
+    assert ids.name == "spm_unit_id"
+    assert diagnostics == {
+        "method": "native_spm_id",
+        "native_id_column": "person_spm_unit_id",
+        "used_columns": ["person_spm_unit_id"],
+        "missing_recommended_columns": [],
+        "fallback_rules_used": [],
+        "confidence": "native",
+    }
+
+
+def test_spm_unit_id_preserves_native_spm_unit_id():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "household_id": [10, 10, 20],
+            "spm_unit_id": [100, 101, 200],
+        }
+    )
+
+    ids = spm_unit_id(persons)
+
+    assert ids.tolist() == [100, 101, 200]
+
+
+def test_spm_unit_id_uses_family_and_unmarried_partner_links():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "household_id": [10, 10, 10, 20],
+            "family_id": [100, 200, 200, 300],
+            "unmarried_partner_id": [2, 1, None, None],
+            "age": [35, 34, 8, 70],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[1] == ids.iloc[2]
+    assert ids.iloc[3] != ids.iloc[0]
+    assert diagnostics["method"] == "census_relationship_rules"
+    assert diagnostics["confidence"] == "rule_based"
+    assert "link_unmarried_partners" in diagnostics["fallback_rules_used"]
+
+
+def test_spm_unit_id_uses_asec_line_number_parent_pointers():
+    persons = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1, 1],
+            "P_SEQ": [1, 2, 3],
+            "A_LINENO": [10, 20, 30],
+            "PEPAR1": [-1, 10, -1],
+            "PEPAR2": [-1, -1, -1],
+            "A_AGE": [45, 12, 40],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[2] != ids.iloc[0]
+    assert "link_parent_child" in diagnostics["fallback_rules_used"]
+    assert {"A_LINENO", "PEPAR1", "PEPAR2"}.issubset(
+        diagnostics["used_columns"]
+    )
+
+
+def test_spm_unit_id_uses_asec_spm_assignment_flags():
+    persons = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1, 2, 2, 3, 3],
+            "PF_SEQ": [1, 2, 1, 2, 1, 2],
+            "A_AGE": [30, 31, 45, 7, 28, 29],
+            "SPM_WCOHABIT": [1, 1, 0, 0, 0, 0],
+            "SPM_WFOSTER22": [0, 0, 1, 1, 0, 0],
+            "SPM_WUI_LT15": [0, 0, 1, 1, 0, 0],
+            "SPM_WNEWPARENT": [0, 0, 0, 0, 1, 1],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[2] == ids.iloc[3]
+    assert ids.iloc[4] == ids.iloc[5]
+    assert (
+        "merge_census_cohabiting_unit_flags"
+        in diagnostics["fallback_rules_used"]
+    )
+    assert (
+        "merge_census_foster_under_22_flags"
+        in diagnostics["fallback_rules_used"]
+    )
+    assert (
+        "merge_census_unrelated_under_15_flags"
+        in diagnostics["fallback_rules_used"]
+    )
+    assert (
+        "merge_census_new_parent_flags" in diagnostics["fallback_rules_used"]
+    )
+
+
+def test_spm_unit_id_prefers_partner_links_over_cohabiting_unit_flag():
+    persons = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1, 1, 1],
+            "A_LINENO": [1, 2, 3, 4],
+            "PF_SEQ": [1, 2, 3, 4],
+            "PECOHAB": [2, 1, 4, 3],
+            "SPM_WCOHABIT": [1, 1, 1, 1],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[2] == ids.iloc[3]
+    assert ids.iloc[0] != ids.iloc[2]
+    assert "link_unmarried_partners" in diagnostics["fallback_rules_used"]
+    assert (
+        "merge_census_cohabiting_unit_flags"
+        not in diagnostics["fallback_rules_used"]
+    )
+
+
+def test_spm_unit_id_handles_asec_family_relationship_codes():
+    persons = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1, 1, 1, 1],
+            "A_FAMREL": [1, 2, 3, 0, 4],
+        }
+    )
+
+    ids = spm_unit_id(persons)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[1] == ids.iloc[2]
+    assert ids.iloc[3] != ids.iloc[0]
+    assert ids.iloc[4] != ids.iloc[0]
+
+
+def test_spm_unit_id_prefers_unrelated_child_flags_over_generic_relationship():
+    persons = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1, 1, 1],
+            "PF_SEQ": [1, 2, 2, 3],
+            "A_AGE": [62, 40, 5, 0],
+            "A_FAMREL": [0, 1, 3, 0],
+            "SPM_WUI_LT15": [1, 0, 0, 1],
+        }
+    )
+
+    ids = spm_unit_id(persons)
+
+    assert ids.iloc[0] == ids.iloc[3]
+    assert ids.iloc[1] == ids.iloc[2]
+    assert ids.iloc[0] != ids.iloc[1]
+
+
+def test_spm_unit_id_attaches_unrelated_children_under_15():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4, 5],
+            "household_id": [10, 10, 10, 10, 10],
+            "age": [40, 39, 10, 14, 15],
+            "relationship_to_head": [0, 1, 2, 3, 3],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[1] == ids.iloc[2]
+    assert ids.iloc[2] == ids.iloc[3]
+    assert ids.iloc[4] != ids.iloc[0]
+    assert diagnostics["method"] == "census_relationship_rules"
+    assert diagnostics["fallback_rules_used"] == [
+        "attach_unrelated_under_15_to_reference_unit"
+    ]
+
+
+def test_spm_unit_id_attaches_foster_children_under_22():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "household_id": [10, 10, 10],
+            "age": [45, 16, 22],
+            "relationship_to_head": [0, 3, 3],
+            "is_foster_child": [False, True, True],
+        }
+    )
+
+    ids, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert ids.iloc[0] == ids.iloc[1]
+    assert ids.iloc[2] != ids.iloc[0]
+    assert diagnostics["fallback_rules_used"] == [
+        "attach_foster_under_22_to_reference_unit"
+    ]
+
+
+def test_spm_unit_id_diagnostics_describe_assignment_not_profile():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2],
+            "household_id": [10, 10],
+            "age": [30, 20],
+        }
+    )
+
+    _, diagnostics = spm_unit_id(persons, diagnostics=True)
+
+    assert diagnostics["method"] == "fallback_household_rules"
+    assert diagnostics["fallback_rules_used"] == ["household_level_fallback"]
+    assert "num_spm_units" not in diagnostics
+    assert "child_only_units" not in diagnostics
+    assert "avg_unit_size" not in diagnostics

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,90 @@
+"""Tests for SPM validation helpers."""
+
+import pandas as pd
+
+from spm_calculator import spm_threshold_match, spm_unit_id_match
+
+
+def test_spm_unit_id_match_ignores_arbitrary_id_labels():
+    persons = pd.DataFrame(
+        {
+            "household_id": [10, 10, 10, 20],
+            "SPM_ID": [100, 100, 101, 200],
+            "predicted": [5, 5, 6, 7],
+        }
+    )
+
+    report = spm_unit_id_match(
+        persons,
+        predicted_spm_unit_id="predicted",
+    )
+
+    assert report["match"] is True
+    assert report["households"] == 2
+    assert report["matching_households"] == 2
+    assert report["household_match_rate"] == 1.0
+    assert report["person_weighted_household_match_rate"] == 1.0
+
+
+def test_spm_unit_id_match_can_infer_against_native_reference():
+    persons = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "household_id": [10, 10, 10, 10],
+            "age": [40, 38, 12, 16],
+            "relationship_to_head": [0, 1, 3, 3],
+            "SPM_ID": [100, 100, 100, 101],
+        }
+    )
+
+    report = spm_unit_id_match(persons)
+
+    assert report["match"] is True
+    assert report["predicted_source"] == "inferred"
+
+
+def test_spm_unit_id_match_reports_mismatching_households():
+    persons = pd.DataFrame(
+        {
+            "household_id": [10, 10, 20, 20],
+            "SPM_ID": [100, 100, 200, 201],
+            "predicted": [5, 6, 7, 8],
+        }
+    )
+
+    report = spm_unit_id_match(
+        persons,
+        predicted_spm_unit_id="predicted",
+    )
+
+    assert report["match"] is False
+    assert report["matching_households"] == 1
+    assert report["mismatching_households"] == 1
+    assert report["mismatching_household_ids"] == [10]
+
+
+def test_spm_threshold_match_accepts_small_errors_with_tolerance():
+    report = spm_threshold_match(
+        calculated=pd.Series([10_000.50, 20_001.00]),
+        reference=pd.Series([10_000.00, 20_000.00]),
+        atol=1.0,
+        rtol=0.0,
+    )
+
+    assert report["match"] is True
+    assert report["matching_values"] == 2
+    assert report["max_abs_error"] == 1.0
+
+
+def test_spm_threshold_match_reports_large_errors():
+    report = spm_threshold_match(
+        calculated=pd.Series([10_000.00, 20_005.00], index=["a", "b"]),
+        reference=pd.Series([10_000.00, 20_000.00]),
+        atol=1.0,
+        rtol=0.0,
+    )
+
+    assert report["match"] is False
+    assert report["matching_values"] == 1
+    assert report["mismatching_values"] == 1
+    assert report["mismatching_indices"] == ["b"]


### PR DESCRIPTION
## Summary

Closes #25.

Adds public helpers for reconstructing person-level SPM resource-unit IDs and validating them against native Census IDs or threshold references.

## Changes

- Add `spm_unit_id`, preserving native `SPM_ID`/`person_spm_unit_id`/`spm_unit_id` when available and otherwise reconstructing from household, family, pointer, relationship, foster, and Census SPM assignment fields.
- Prefer direct Census cohabiting partner pointers such as `PECOHAB` over broad `SPM_WCOHABIT` flags, while retaining `SPM_WCOHABIT` as a fallback when no partner pointer exists.
- Add `spm_unit_id_match` for within-household partition comparison up to arbitrary relabeling, plus `spm_threshold_match` for threshold parity checks.
- Add optional ASEC parity tests gated by `SPM_CALCULATOR_ASEC_H5`.
- Document required, recommended, optional, and unsupported inputs.

## Validation

- `uv run --extra dev python -m pytest -q` -> 151 passed, 18 skipped
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev black --check .` -> passed
- `SPM_CALCULATOR_ASEC_H5=/Users/maxghenis/PolicyEngine/policyengine-us-data/policyengine_us_data/storage/census_cps_2024.h5 pytest -q tests/test_asec_parity.py` -> 2 passed
- Raw Census `pppub25.csv` parity check with `PECOHAB`: 55,762 / 55,762 household partitions matched