### PR TITLE
Add PolicyEngine header

### DIFF
--- a/web/app/layout.jsx
+++ b/web/app/layout.jsx
@@ -1,5 +1,6 @@
 import Script from "next/script";
 import "./globals.css";
+import PolicyEngineHeader from "../src/components/PolicyEngineHeader";
 
 const GA_ID = "G-2YHG89FY0N";
 const TOOL_NAME = "spm-calculator";
@@ -131,7 +132,10 @@ export default function RootLayout({ children }) {
           `}
         </Script>
       </head>
-      <body>{children}</body>
+      <body>
+        <PolicyEngineHeader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/src/components/PolicyEngineHeader.jsx
+++ b/web/src/components/PolicyEngineHeader.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@policyengine/ui-kit";
+
+const navItems = [
+  { label: "Research", href: "https://policyengine.org/us/research" },
+  { label: "Model", href: "https://policyengine.org/us/model" },
+  { label: "API", href: "https://policyengine.org/us/api" },
+  {
+    label: "About",
+    href: "https://policyengine.org/us/team",
+    children: [
+      { label: "Team", href: "https://policyengine.org/us/team" },
+      { label: "Supporters", href: "https://policyengine.org/us/supporters" },
+    ],
+  },
+  { label: "Donate", href: "https://policyengine.org/us/donate" },
+];
+
+const countries = [
+  { id: "us", label: "United States" },
+  { id: "uk", label: "United Kingdom" },
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="us"
+      logoHref="https://policyengine.org/us"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n- render the shared ui-kit PolicyEngine header above the SPM calculator\n- keep existing metadata, analytics, tests, and multizone base path unchanged\n\n## Tests\n- bun run test\n- bun run build