### PR TITLE
Wrap layout with @policyengine/ui-kit PolicyEngineShell

### DIFF
--- a/web/app/layout.jsx
+++ b/web/app/layout.jsx
@@ -1,3 +1,6 @@
+import { PolicyEngineShell } from "@policyengine/ui-kit/layout";
+import "@policyengine/ui-kit/styles.css";
+
 import Script from "next/script";
 import "./globals.css";
 
@@ -131,7 +134,9 @@ export default function RootLayout({ children }) {
           `}
         </Script>
       </head>
-      <body>{children}</body>
+      <body>
+        <PolicyEngineShell country="us">{children}        </PolicyEngineShell>
+      </body>
     </html>
   );
 }

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "spm-calculator-web",
       "dependencies": {
-        "@policyengine/ui-kit": "^0.9.0",
+        "@policyengine/ui-kit": "^0.12.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -152,7 +152,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
-    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.9.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-oPqMSr+qSdY/63xZ8b7dO3q5Bhceg5UQCiZ/m4tOqcywviQk5VO8FKzkUR8pzmFIv8Q4TB3b2OB0ZKfo6UzHQw=="],
+    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.12.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-Psz6j9ykKjGzrvEHR2Evv1EbOS/H7eBM5iydd7GfxCD2eQgu6uMWw2sLZXNFfmhKKDxevheynnaATcKJOw5QGQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@policyengine/ui-kit": "^0.9.0",
+    "@policyengine/ui-kit": "^0.12.0",
     "next": "^16.2.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
Wraps the app's root layout with `<PolicyEngineShell country="us">` from `@policyengine/ui-kit ^0.12.0` so policyengine.org/us/* renders the PolicyEngine site header + footer around this tool. Adds the ui-kit dependency. Layout edit is mechanical and idempotent.